### PR TITLE
feat: EasyEffects preset selector + fix accent color mapping in Palette

### DIFF
--- a/versions/V1/Palette.js
+++ b/versions/V1/Palette.js
@@ -8,8 +8,8 @@ const WANTED = {
     foreground: "ink",
     color7:     "inkDeep",
     color8:     "sumi",
-    accent:     "indigo",
-    color1:     "sealRaw",
+    accent:     "sealRaw",
+    color4:     "indigo",
 };
 
 const LINE = /^\s*([A-Za-z_][A-Za-z0-9_]*)\s*=\s*"([^"]+)"/;

--- a/versions/V1/panels/VolumePanel.qml
+++ b/versions/V1/panels/VolumePanel.qml
@@ -20,6 +20,8 @@ PanelWindow {
     property bool   muted:    false
     property string portType: "default"
     property bool   micMuted: false
+    property var    eePresets: []
+    property string eeActive:  ""
 
     property real reveal: root.volVisible ? 1 : 0
     Behavior on reveal {
@@ -188,6 +190,53 @@ PanelWindow {
 
             Rectangle { width: parent.width; height: 1; color: root.sep }
 
+            // ── easyeffects presets ──
+            Text {
+                text: "EFFECTS"
+                color: root.sumi
+                font.family: root.mono; font.pixelSize: 10; font.letterSpacing: 1
+                visible: volPanel.eePresets.length > 0
+            }
+
+            Repeater {
+                model: volPanel.eePresets
+                Rectangle {
+                    width: col.width
+                    height: 26; radius: 4
+                    color: volPanel.eeActive === modelData
+                        ? Qt.rgba(root.seal.r, root.seal.g, root.seal.b, 0.15)
+                        : prMa.containsMouse
+                            ? Qt.rgba(root.ink.r, root.ink.g, root.ink.b, 0.08)
+                            : "transparent"
+                    border.color: volPanel.eeActive === modelData ? root.seal : "transparent"
+                    border.width: 1
+                    Behavior on color { ColorAnimation { duration: 100 } }
+                    Text {
+                        anchors.verticalCenter: parent.verticalCenter
+                        anchors.left: parent.left; anchors.leftMargin: 8
+                        anchors.right: parent.right; anchors.rightMargin: 8
+                        text: modelData
+                        color: volPanel.eeActive === modelData ? root.seal : root.ink
+                        font.family: root.mono; font.pixelSize: 11
+                        elide: Text.ElideRight
+                    }
+                    MouseArea {
+                        id: prMa
+                        anchors.fill: parent
+                        hoverEnabled: true
+                        cursorShape: Qt.PointingHandCursor
+                        onClicked: {
+                            volPanel.eeActive = modelData
+                            eeLoadProc.preset = modelData
+                            eeLoadProc.running = false
+                            eeLoadProc.running = true
+                        }
+                    }
+                }
+            }
+
+            Rectangle { width: parent.width; height: 1; color: root.sep; visible: volPanel.eePresets.length > 0 }
+
             // ── mic section ──
             Text {
                 text: "INPUT"
@@ -302,6 +351,34 @@ PanelWindow {
     Process { id: audioRunner;   command: ["bash", "-c", "omarchy-launch-audio"] }
 
     Process {
+        id: eeListProc
+        command: ["bash", "-c", "easyeffects -p 2>/dev/null | grep -E '^[0-9]' | cut -f2-"]
+        stdout: SplitParser {
+            onRead: function(line) {
+                var t = line.trim()
+                if (t) volPanel.eePresets = volPanel.eePresets.concat([t])
+            }
+        }
+    }
+
+    Process {
+        id: eeActiveProc
+        command: ["bash", "-c", "easyeffects -a output 2>/dev/null"]
+        stdout: StdioCollector {
+            onStreamFinished: {
+                var t = this.text.trim()
+                if (t) volPanel.eeActive = t
+            }
+        }
+    }
+
+    Process {
+        id: eeLoadProc
+        property string preset: ""
+        command: ["easyeffects", "-l", eeLoadProc.preset]
+    }
+
+    Process {
         id: micData
         command: ["bash", "-c", "pactl get-source-mute @DEFAULT_SOURCE@ 2>/dev/null | awk '{print $2}'"]
         running: false
@@ -319,6 +396,11 @@ PanelWindow {
             audioData.running = true
             micData.running = false
             micData.running = true
+            volPanel.eePresets = []
+            eeListProc.running = false
+            eeListProc.running = true
+            eeActiveProc.running = false
+            eeActiveProc.running = true
         }
     }
 }


### PR DESCRIPTION
## What

Two independent improvements to the volume panel and theme system.

---

### 1. EasyEffects preset selector (VolumePanel)

Adds an **EFFECTS** section to the volume panel that shows all available EasyEffects output presets. The currently active preset is highlighted; clicking any item applies it immediately.

- On panel open, runs `easyeffects -p` to list presets and `easyeffects -a output` to get the active one
- Applies via `easyeffects -l <preset>`
- Section is **hidden entirely** when EasyEffects is not installed or has no presets — zero visual impact for users who don't use it
- No new dependencies — `easyeffects` CLI is part of the app itself

---

### 2. Palette: use `accent` as primary bar color

Maps `accent → sealRaw` instead of `color1 → sealRaw` so the bar's main accent color follows the theme's `accent` key rather than `color1`, which is typically red in most color schemes and clashes with non-red themes.

Maps `color4 → indigo` (secondary accent: battery charging, network upload indicators) — `color4` is usually the same hue as `accent`, keeping secondary indicators harmonious with the primary color.

This makes the bar feel properly themed across the full range of Omarchy color schemes.

✦ Generated with [Claude Code](https://claude.ai/claude-code)