### PR TITLE
feat: widget visibility toggles in the control panel

### DIFF
--- a/versions/V1/Bar.qml
+++ b/versions/V1/Bar.qml
@@ -50,9 +50,12 @@ PanelWindow {
             }
             return runs
         }
-        // is atom non-empty? (only atom 3 = mpris/batt/bri can be empty)
+        // is atom non-empty? any group can empty out now that widgets are toggleable
         function atomVisible(i) {
+            if (i === 0) return launcherW.width > 1 || wsW.width > 1 || statusCluster.width > 1
+            if (i === 1) return memW.width > 1 || cpuW.width > 1 || audioW.width > 1 || claudeW.width > 1
             if (i === 3) return mprisW.width > 1 || battW.width > 1 || briW.width > 1
+            if (i === 4) return networkW.width > 1 || ppW.width > 1 || btW.width > 1
             return true
         }
         // content edges (used when an atom is the last/first VISIBLE in a run but
@@ -259,6 +262,7 @@ PanelWindow {
             WeatherWidget {
                 id: weather
                 root: bar.root
+                shown: bar.root.modWeather
             }
             ClockWidget {
                 id: clock
@@ -311,12 +315,14 @@ PanelWindow {
             id: wsW
             anchors { left: launcherW.right; leftMargin: 10; verticalCenter: sLeft.verticalCenter }
             root: bar.root
+            shown: bar.root.modWorkspace
         }
         // ── status cluster (arch · tray · notif) in one shared pill ──
         Item {
             id: statusCluster
             anchors { left: wsW.right; leftMargin: 8; verticalCenter: sLeft.verticalCenter }
-            implicitWidth: statusRow.implicitWidth + 18
+            visible: root.modStatus
+            implicitWidth: root.modStatus ? statusRow.implicitWidth + 18 : 0
             implicitHeight: 28
 
             Rectangle {
@@ -370,21 +376,25 @@ PanelWindow {
             id: memW
             anchors { left: parent.left; leftMargin: gArchL.x + gArchL.width + 4; verticalCenter: sLeft.verticalCenter }
             root: bar.root
+            shown: bar.root.modMemory
         }
         CpuWidget {
             id: cpuW
             anchors { left: memW.right; leftMargin: 4; verticalCenter: sLeft.verticalCenter }
             root: bar.root
+            shown: bar.root.modCpu
         }
         AudioWidget {
             id: audioW
             anchors { left: cpuW.right; leftMargin: 4; verticalCenter: sLeft.verticalCenter }
             root: bar.root
+            shown: bar.root.modVolume
         }
         ClaudeWidget {
             id: claudeW
             anchors { left: audioW.right; leftMargin: claudeW.claudeActive ? 4 : 0; verticalCenter: sLeft.verticalCenter }
             root: bar.root
+            shown: bar.root.modClaude
         }
 
         // ── separator mon (split/merge monitors) ──
@@ -414,16 +424,19 @@ PanelWindow {
             id: btW
             anchors { right: sRight.right; rightMargin: 4; verticalCenter: sRight.verticalCenter }
             root: bar.root
+            shown: bar.root.modBluetooth
         }
         PowerProfileWidget {
             id: ppW
             anchors { right: btW.left; rightMargin: 4; verticalCenter: sRight.verticalCenter }
             root: bar.root
+            shown: bar.root.modPower
         }
         NetworkWidget {
             id: networkW
             anchors { right: ppW.left; rightMargin: 4; verticalCenter: sRight.verticalCenter }
             root: bar.root
+            shown: bar.root.modNetwork
         }
         // ── separator net (split/merge net) ──
         Text {
@@ -453,16 +466,19 @@ PanelWindow {
             id: briW
             anchors { right: gNetL.left; rightMargin: briW.hasBacklight ? 4 : 0; verticalCenter: sRight.verticalCenter }
             root: bar.root
+            shown: bar.root.modBrightness
         }
         BatteryWidget {
             id: battW
             anchors { right: briW.left; rightMargin: battW.hasBattery ? 4 : 0; verticalCenter: sRight.verticalCenter }
             root: bar.root
+            shown: bar.root.modBattery
         }
         MprisWidget {
             id: mprisW
             anchors { right: battW.left; rightMargin: 4; verticalCenter: sRight.verticalCenter }
             root: bar.root
+            shown: bar.root.modMedia
         }
 
         // ── separator mpris-left (peel/merge right cluster) ──

--- a/versions/V1/Theme.qml
+++ b/versions/V1/Theme.qml
@@ -153,6 +153,7 @@ Item {
     property bool modMemory:     true
     property bool modCpu:        true
     property bool modVolume:     true
+    property bool modClaude:     true
     property bool modWeather:    true
     property bool modNetwork:    true
     property bool modPower:      true

--- a/versions/V1/modules/AudioWidget.qml
+++ b/versions/V1/modules/AudioWidget.qml
@@ -5,6 +5,7 @@ import Quickshell.Io
 Item {
     id: rootMod
     required property var root
+    property bool shown: true
 
     property int volume: 50
     property bool muted: false
@@ -14,7 +15,8 @@ Item {
         ? "Muted · " + volume + "%"
         : "Audio " + volume + "%"
 
-    implicitWidth: row.implicitWidth + 18
+    visible: shown
+    implicitWidth: shown ? row.implicitWidth + 18 : 0
     implicitHeight: 28
 
     Rectangle {

--- a/versions/V1/modules/BatteryWidget.qml
+++ b/versions/V1/modules/BatteryWidget.qml
@@ -5,6 +5,7 @@ import Quickshell.Services.UPower
 Item {
     id: rootMod
     required property var root
+    property bool shown: true
 
     // event-driven UPower data — updates instantly on plug / unplug
     readonly property var dev: UPower.displayDevice
@@ -34,9 +35,9 @@ Item {
         : (low ? root.seal
         : Qt.rgba(root.ink.r, root.ink.g, root.ink.b, 0.7))
 
-    implicitWidth:  hasBattery ? (row.implicitWidth + 18) : 0
+    implicitWidth:  (shown && hasBattery) ? (row.implicitWidth + 18) : 0
     implicitHeight: 28
-    visible: hasBattery
+    visible: shown && hasBattery
     clip: true
 
     Behavior on implicitWidth {

--- a/versions/V1/modules/BluetoothWidget.qml
+++ b/versions/V1/modules/BluetoothWidget.qml
@@ -6,6 +6,7 @@ import "../IconMap.js" as IconMap
 Item {
     id: rootMod
     required property var root
+    property bool shown: true
 
     property bool btOn:       false
     property bool connected:  false
@@ -19,7 +20,8 @@ Item {
         ? "Bluetooth · " + numConnected + " connected"
         : (btOn ? "Bluetooth on" : "Bluetooth off")
 
-    implicitWidth: row.implicitWidth + 18
+    visible: shown
+    implicitWidth: shown ? row.implicitWidth + 18 : 0
     implicitHeight: 28
 
     Rectangle {

--- a/versions/V1/modules/BrightnessWidget.qml
+++ b/versions/V1/modules/BrightnessWidget.qml
@@ -5,6 +5,7 @@ import Quickshell.Io
 Item {
     id: rootMod
     required property var root
+    property bool shown: true
 
     property bool   hasBacklight: false
     property int    percent:      0
@@ -12,9 +13,9 @@ Item {
 
     readonly property string tooltipText: "Brightness · " + percent + "%"
 
-    implicitWidth:  hasBacklight ? (row.implicitWidth + 18) : 0
+    implicitWidth:  (shown && hasBacklight) ? (row.implicitWidth + 18) : 0
     implicitHeight: 28
-    visible: hasBacklight
+    visible: shown && hasBacklight
     clip: true
 
     Behavior on implicitWidth {

--- a/versions/V1/modules/ClaudeWidget.qml
+++ b/versions/V1/modules/ClaudeWidget.qml
@@ -6,6 +6,7 @@ Item {
     id: rootMod
     required property var root
 
+    property bool shown: true
     property bool claudeActive: false
     property int  pct5h:   0
     property bool blocked: false
@@ -13,8 +14,8 @@ Item {
 
     readonly property string tooltipText: tooltipFull || ("Claude " + pct5h + "%")
 
-    visible: claudeActive
-    implicitWidth: claudeActive ? row.implicitWidth + 18 : 0
+    visible: shown && claudeActive
+    implicitWidth: (shown && claudeActive) ? row.implicitWidth + 18 : 0
     implicitHeight: 28
     clip: true
 

--- a/versions/V1/modules/CpuWidget.qml
+++ b/versions/V1/modules/CpuWidget.qml
@@ -5,8 +5,10 @@ import Quickshell.Io
 Item {
     id: rootMod
     required property var root
+    property bool shown: true
 
-    implicitWidth: row.implicitWidth + 18
+    visible: shown
+    implicitWidth: shown ? row.implicitWidth + 18 : 0
     implicitHeight: 28
 
     property int percent: 0

--- a/versions/V1/modules/MemoryWidget.qml
+++ b/versions/V1/modules/MemoryWidget.qml
@@ -5,8 +5,10 @@ import Quickshell.Io
 Item {
     id: rootMod
     required property var root
+    property bool shown: true
 
-    implicitWidth: row.implicitWidth + 18
+    visible: shown
+    implicitWidth: shown ? row.implicitWidth + 18 : 0
     implicitHeight: 28
 
     property int percent: 0

--- a/versions/V1/modules/MprisWidget.qml
+++ b/versions/V1/modules/MprisWidget.qml
@@ -5,6 +5,7 @@ import Quickshell.Services.Mpris
 Item {
     id: rootMod
     required property var root
+    property bool shown: true
 
     // shared player selection (ghost-filtering) — see MprisSelect.qml
     MprisSelect { id: sel }
@@ -59,7 +60,8 @@ Item {
     }
     onPlayingChanged: { if (!playing) dropAnim.restart() }
 
-    implicitWidth: active ? (row.implicitWidth + 18) : (idleNote.implicitWidth + 16)
+    visible: shown
+    implicitWidth: shown ? (active ? (row.implicitWidth + 18) : (idleNote.implicitWidth + 16)) : 0
     implicitHeight: 28
     clip: true
 

--- a/versions/V1/modules/NetworkWidget.qml
+++ b/versions/V1/modules/NetworkWidget.qml
@@ -6,6 +6,7 @@ import "../IconMap.js" as IconMap
 Item {
     id: rootMod
     required property var root
+    property bool shown: true
 
     property string mode:   "none"  // "wifi" | "ethernet" | "none"
     property string ssid:   ""
@@ -55,7 +56,8 @@ Item {
         return "Offline"
     }
 
-    implicitWidth: row.implicitWidth + 18
+    visible: shown
+    implicitWidth: shown ? row.implicitWidth + 18 : 0
     implicitHeight: 28
 
     Rectangle {

--- a/versions/V1/modules/PowerProfileWidget.qml
+++ b/versions/V1/modules/PowerProfileWidget.qml
@@ -5,6 +5,7 @@ import Quickshell.Io
 Item {
     id: rootMod
     required property var root
+    property bool shown: true
 
     property string profile: root.powerProfileCurrent
 
@@ -24,7 +25,8 @@ Item {
         return "Balanced"
     }
 
-    implicitWidth: row.implicitWidth + 18
+    visible: shown
+    implicitWidth: shown ? row.implicitWidth + 18 : 0
     implicitHeight: 28
 
     Rectangle {

--- a/versions/V1/modules/WeatherWidget.qml
+++ b/versions/V1/modules/WeatherWidget.qml
@@ -5,6 +5,7 @@ import Quickshell.Io
 Item {
     id: rootMod
     required property var root
+    property bool shown: true
 
     property string weatherIcon: "·"
     property string weatherPlace: ""
@@ -19,7 +20,8 @@ Item {
             ? (weatherPlace ? weatherPlace + " · " : "") + weatherTemp + "°C" + (weatherDesc ? " / " + weatherDesc : "")
             : "Weather…")
 
-    implicitWidth: ico.implicitWidth
+    visible: shown
+    implicitWidth: shown ? ico.implicitWidth : 0
     implicitHeight: 28
 
     Process {

--- a/versions/V1/modules/WorkspaceWidget.qml
+++ b/versions/V1/modules/WorkspaceWidget.qml
@@ -4,8 +4,10 @@ import QtQuick
 Item {
     id: wsWidget
     required property var root
+    property bool shown: true
 
-    implicitWidth: wsRow.implicitWidth
+    visible: shown
+    implicitWidth: shown ? wsRow.implicitWidth : 0
     implicitHeight: 28
 
     Rectangle {

--- a/versions/V1/panels/ControlPanel.qml
+++ b/versions/V1/panels/ControlPanel.qml
@@ -22,6 +22,23 @@ PanelWindow {
         { key: "splitMprisL", label: "Right" },
         { key: "splitNet",    label: "Network" }
     ]
+
+    // toggleable bar modules, ordered left → right as they sit on the bar
+    readonly property var widgets: [
+        { key: "modWorkspace",  label: "Workspaces" },
+        { key: "modStatus",     label: "Status" },
+        { key: "modMemory",     label: "Memory" },
+        { key: "modCpu",        label: "CPU" },
+        { key: "modVolume",     label: "Volume" },
+        { key: "modClaude",     label: "Claude" },
+        { key: "modWeather",    label: "Weather" },
+        { key: "modMedia",      label: "Media" },
+        { key: "modBattery",    label: "Battery" },
+        { key: "modBrightness", label: "Brightness" },
+        { key: "modNetwork",    label: "Network" },
+        { key: "modPower",      label: "Power" },
+        { key: "modBluetooth",  label: "Bluetooth" }
+    ]
     readonly property bool anySplit: root.splitArch || root.splitMon
                                   || root.splitNet || root.splitMprisL
 
@@ -211,6 +228,31 @@ PanelWindow {
 
             Rectangle { width: parent.width; height: 1; color: root.sep }
 
+            // ── WIDGETS: show / hide individual bar modules ──
+            Text {
+                text: "WIDGETS"
+                color: root.sumi; font.family: root.mono; font.pixelSize: 10; font.letterSpacing: 1
+            }
+            Grid {
+                width: parent.width
+                columns: 2
+                columnSpacing: 8
+                rowSpacing: 8
+                Repeater {
+                    model: ctrlPanel.widgets
+                    delegate: ToggleTile {
+                        required property var modelData
+                        width: (col.width - 8) / 2
+                        root: ctrlPanel.root
+                        label: modelData.label
+                        active: ctrlPanel.root[modelData.key] === true
+                        onToggled: ctrlPanel.root[modelData.key] = !ctrlPanel.root[modelData.key]
+                    }
+                }
+            }
+
+            Rectangle { width: parent.width; height: 1; color: root.sep }
+
             // ── SPLITS ──
             Text {
                 text: "SPLITS"
@@ -224,35 +266,13 @@ PanelWindow {
 
                 Repeater {
                     model: ctrlPanel.splits
-                    delegate: Rectangle {
-                        id: splitTile
+                    delegate: ToggleTile {
                         required property var modelData
-                        readonly property bool active: root[modelData.key] === true
-                        readonly property bool hovered: splitMa.containsMouse
                         width: (col.width - 8) / 2
-                        height: 25
-                        radius: 4
-                        color: active ? Qt.rgba(root.seal.r, root.seal.g, root.seal.b, 0.18)
-                                      : hovered ? Qt.rgba(root.ink.r, root.ink.g, root.ink.b, 0.12)
-                                                : Qt.rgba(root.ink.r, root.ink.g, root.ink.b, 0.06)
-                        border.color: (active || hovered) ? root.seal : root.sep
-                        border.width: 1
-                        Behavior on color { ColorAnimation { duration: 120 } }
-
-                        Text {
-                            anchors.centerIn: parent
-                            text: splitTile.modelData.label
-                            color: (splitTile.active || splitTile.hovered) ? root.seal : root.ink
-                            font.family: root.mono; font.pixelSize: 11
-                            font.weight: splitTile.active ? Font.Medium : Font.Normal
-                        }
-                        MouseArea {
-                            id: splitMa
-                            anchors.fill: parent
-                            hoverEnabled: true
-                            cursorShape: Qt.PointingHandCursor
-                            onClicked: root[splitTile.modelData.key] = !root[splitTile.modelData.key]
-                        }
+                        root: ctrlPanel.root
+                        label: modelData.label
+                        active: ctrlPanel.root[modelData.key] === true
+                        onToggled: ctrlPanel.root[modelData.key] = !ctrlPanel.root[modelData.key]
                     }
                 }
             }

--- a/versions/V1/panels/ToggleTile.qml
+++ b/versions/V1/panels/ToggleTile.qml
@@ -1,0 +1,40 @@
+import QtQuick
+
+// Stateful on/off tile for the control panel toggle grids.
+// The parent sets the width; styling follows the active / hover state.
+Rectangle {
+    id: tile
+    required property var root
+    property string label
+    property bool active: false
+    property color accent: root.seal
+    signal toggled()
+
+    readonly property bool hovered: ma.containsMouse
+
+    height: 25
+    radius: 4
+    color: active  ? Qt.rgba(accent.r, accent.g, accent.b, 0.18)
+         : hovered ? Qt.rgba(root.ink.r, root.ink.g, root.ink.b, 0.12)
+                   : Qt.rgba(root.ink.r, root.ink.g, root.ink.b, 0.06)
+    border.color: (active || hovered) ? accent : root.sep
+    border.width: 1
+    Behavior on color { ColorAnimation { duration: 120 } }
+
+    Text {
+        anchors.centerIn: parent
+        text: tile.label
+        color: (tile.active || tile.hovered) ? tile.accent : tile.root.ink
+        font.family: tile.root.mono
+        font.pixelSize: 11
+        font.weight: tile.active ? Font.Medium : Font.Normal
+    }
+
+    MouseArea {
+        id: ma
+        anchors.fill: parent
+        hoverEnabled: true
+        cursorShape: Qt.PointingHandCursor
+        onClicked: tile.toggled()
+    }
+}


### PR DESCRIPTION
## What

Finishes the half-built module-toggle feature. `Theme.qml` already declares a block of `mod*` flags commented "controlled by ControlPanel", but nothing referenced them and the panel had no UI, so they were effectively dead code. This wires them up.

A new **WIDGETS** section in the control panel lets you show/hide individual bar modules: Workspaces, Status, Memory, CPU, Volume, Claude, Weather, Media, Battery, Brightness, Network, Power, Bluetooth.

## Why

On dense or high-DPI / fractionally-scaled bars (for example a 2560x1600 panel at scale 1.6, which is 1600 logical px) the left content can run wide and crowd the centered clock. Letting people hide modules they do not use declutters the bar and relieves that crowding as a side effect. It also makes the bar feel personal: show only what you want.

## How

- Each toggleable module gains a generic `shown` property and hides itself when false (`visible: shown`, `implicitWidth: 0`). This is the same self-hiding pattern `ClaudeWidget` already used, so modules stay generic and do not reference the theme flags directly.
- `Bar.qml` passes `shown: root.mod*` to each widget instance and gates the inline status cluster. `atomVisible()` now reports a group as empty when all of its widgets are hidden, so no stray section pill or separator gets drawn.
- New reusable `ToggleTile` component. The existing SPLITS grid is converted onto it (removing duplicated tile markup), and the new WIDGETS section reuses it.
- Adds `modClaude`, the one bar widget the original flag list left out.

## Notes

- **No persistence.** Flags default on and reset on reload, consistent with how the existing splits and bar-color toggles already behave. Persisting these (and ideally the splits / bar-color too) to a small state file via `FileView` plus a JSON adapter would be a natural follow-up. Happy to do that in a separate PR if you would want it.
- No new dependencies. Tested on Hyprland 0.55 / Quickshell at 2560x1600 @ 1.6 scale: toggling reflows the row cleanly with no empty pills, and every widget restores correctly when re-enabled.
