### PR TITLE
fix(VolumePanel): show real name for sinks with (null) description

### DIFF
--- a/versions/V1/panels/VolumePanel.qml
+++ b/versions/V1/panels/VolumePanel.qml
@@ -468,8 +468,14 @@ PanelWindow {
                 var out = []
                 try {
                     var j = JSON.parse(raw)
-                    for (var i = 0; i < j.length; i++)
-                        out.push({ name: j[i].name, desc: j[i].description || j[i].name })
+                    for (var i = 0; i < j.length; i++) {
+                        var d = j[i].description
+                        if (!d || d === "(null)") {
+                            var p = j[i].properties || {}
+                            d = p["device.description"] || p["alsa.card_name"] || j[i].name
+                        }
+                        out.push({ name: j[i].name, desc: d })
+                    }
                 } catch (e) {}
                 volPanel.sinks = out
             }


### PR DESCRIPTION
## Problem

On some systems (e.g. CachyOS / PipeWire with certain ALSA cards), `pactl -f json list sinks` returns the literal string `"(null)"` as the `description` field for ALSA sinks instead of a human-readable name. The OUTPUT DEVICE list in the volume panel then shows `(null)` for those entries.

The existing fallback `j[i].description || j[i].name` doesn't help because `"(null)"` is a truthy string — it passes through as-is.

## Fix

When `description` is missing or is the string `"(null)"`, fall back to the sink's `properties` object:
1. `device.description` — always present and human-readable (e.g. `"Razer Barracuda X 2.4"`)
2. `alsa.card_name` — secondary fallback
3. `name` — last resort (the internal ALSA id)

## Before / After

| Before | After |
|--------|-------|
| `(null)` | `Razer Barracuda X 2.4` |
| `(null)` | `Starship/Matisse HD Audio Controller` |

Tested on CachyOS with PipeWire 1.x and two ALSA sinks.