### PR TITLE
Add "animated" (Wallpaper Engine) image-picker mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ Each guide covers one task and links back to this page.
 | [Maintenance and recovery](docs/maintenance-and-recovery.md) | Lifecycle, updates, logs, compatibility, and recovery |
 | [Development](docs/development.md) | Repository startup, tests, linting, and releases |
 | [Architecture](docs/architecture.md) | Variants, controller, state, IPC, and project layout |
+| [Animated wallpaper picker](docs/wallpaper-engine.md) | Optional live Wallpaper Engine picker: compatibility, GPU, invocation |
 
 ## Credits
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -103,11 +103,18 @@ Run picker commands from a terminal:
 barctl="$HOME/.config/quickshell/bin/qs-barctl"
 "$barctl" ipc picker theme
 "$barctl" ipc picker wallpaper
+"$barctl" ipc picker animated      # live Wallpaper Engine wallpapers (optional; needs omarchy-we)
 "$barctl" ipc picker screenshots
 "$barctl" ipc picker videos
 ```
 
 The controller forwards arbitrary targets, functions, and string arguments to the single registered Rise instance. It rejects calls when no instance or more than one matching instance exists.
+
+`picker animated` is a self-disabling integration — it only does anything when the
+optional [`omarchy-we`](https://github.com/dkgamer02ai/omarchy-wallpaper-engine)
+CLI is installed and reports a compatible contract. See
+[Animated (Wallpaper Engine) picker](wallpaper-engine.md) for compatibility, GPU
+implications, and how it works.
 
 ## Route Omarchy keybindings to Rise
 

--- a/docs/wallpaper-engine.md
+++ b/docs/wallpaper-engine.md
@@ -1,0 +1,69 @@
+# Animated (Wallpaper Engine) picker
+
+Rise's image picker has a third mode, `animated`, that lists **live Wallpaper
+Engine wallpapers** (Steam Workshop scene/video wallpapers) and applies them.
+It reuses the existing filmstrip picker (all three styles) and delegates every
+wallpaper action to the external [`omarchy-we`](https://github.com/dkgamer02ai/omarchy-wallpaper-engine)
+CLI, which drives [`linux-wallpaperengine`](https://github.com/Almamu/linux-wallpaperengine).
+
+## Compatibility
+
+This mode is **optional and self-disabling**. Rise never hard-depends on
+`omarchy-we`:
+
+- On startup a single `WallpaperEngineAdapter` runs `omarchy-we ipc version` and
+  enables the mode only if it exits 0 and reports a compatible contract
+  (`ipc >= 1`).
+- On Omarchy 3.8.x, generic Hyprland, or any system without `omarchy-we`, the
+  probe fails and `qs-barctl ipc picker animated` is a no-op. The `theme` and
+  `wallpaper` pickers are unaffected.
+
+## Installation
+
+1. Install `omarchy-we` (see its repo) — it needs Omarchy 4, Steam's Wallpaper
+   Engine, and `linux-wallpaperengine`.
+2. Nothing else to install in Rise. The `animated` mode lights up automatically
+   once the capability probe succeeds.
+
+## Invocation
+
+Bind a key to the IPC route (same shape as the theme/wallpaper pickers):
+
+```lua
+-- ~/.config/hypr/bindings.lua
+o.bind("SUPER + CTRL + SHIFT + W", "Animated wallpaper picker",
+       "~/.config/quickshell/bin/qs-barctl ipc picker animated")
+```
+
+Or call it directly: `qs-barctl ipc picker animated`.
+
+## GPU implications
+
+Live wallpapers keep `linux-wallpaperengine` running and rendering on the GPU
+continuously (heavier than a static image, especially 4K scenes). Two things
+matter:
+
+- **Switching back to a static wallpaper stops the renderer.** Selecting any
+  `theme` or `wallpaper` in the picker calls `omarchy-we ipc kill`, so the GPU
+  renderer is torn down rather than left running hidden behind the static image.
+- On a laptop/iGPU, prefer the video wallpapers over heavy scenes, cap the frame
+  rate via `omarchy-we`, or stop the renderer on battery.
+
+## How it works (architecture)
+
+- `versions/V1/WallpaperEngineAdapter.qml` is the single owner of all
+  `omarchy-we` interaction: capability probe, entry fetch, JSON validation,
+  sanitisation, atomic caching, error state, apply, and renderer teardown. All
+  three picker styles delegate to it — no per-style command pipeline.
+- Entries are consumed as **structured JSON** (`omarchy-we ipc entries`), then
+  every field is control-char-stripped before the picker's row model sees it, so
+  Workshop metadata cannot corrupt the list.
+- The scan cache is replaced atomically (temp file + rename) and only after a
+  validated response, so a failed refresh never truncates it.
+- A non-zero exit or malformed response surfaces an actionable error in the
+  picker instead of an empty "nothing found" state. A failed `set` raises a
+  desktop notification rather than closing the picker silently.
+
+Contract: `omarchy-we ipc {version|entries|current|set <id>|kill}`. `version`
+returns `{"ipc":N,...}`; `entries`/`current` return JSON and exit non-zero on
+failure (treated as an error, not an empty result).

--- a/tests/qs-wallpaper-engine-regression.sh
+++ b/tests/qs-wallpaper-engine-regression.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+# Contract regression for the "animated" (Wallpaper Engine) image-picker mode.
+# Pins the lifecycle/robustness guarantees agreed in review: capability guard,
+# centralized adapter (no duplicated shell pipeline), structured error state,
+# safe serialization, atomic cache, apply feedback, and the transition back to
+# static wallpapers. Static assertions on the QML sources — QML behavior is not
+# executable from bash, so these lock the contracts in place.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+V1="$REPO_ROOT/versions/V1"
+V2="$REPO_ROOT/versions/V1/variants/V2"
+
+PANELS=(
+  "$V1/panels/ImageCarouselPanel.qml"
+  "$V1/panels/ImageCarouselHearthstone.qml"
+  "$V1/panels/ImageCarouselCarousel.qml"
+  "$V2/panels/ImageCarouselPanel.qml"
+  "$V2/panels/ImageCarouselHearthstone.qml"
+  "$V2/panels/ImageCarouselCarousel.qml"
+)
+THEMES=("$V1/Theme.qml" "$V2/Theme.qml")
+ADAPTERS=("$V1/WallpaperEngineAdapter.qml" "$V2/WallpaperEngineAdapter.qml")
+
+fail() { printf 'FAIL: %s\n' "$*" >&2; exit 1; }
+assert_contains() { grep -Fq -- "$2" "$1" || fail "$3: '$1' missing '$2'"; }
+assert_absent()   { grep -Fq -- "$2" "$1" && fail "$3: '$1' unexpectedly contains '$2'" || true; }
+assert_count()    { local n; n="$(grep -Fc -- "$2" "$1" || true)"; [ "$n" = "$3" ] || fail "$4: '$1' has $n of '$2', want $3"; }
+
+# ── 1. IPC route ───────────────────────────────────────────────────────────
+assert_contains "$V1/core/IpcRouter.qml" 'function animated(): void { router.openPicker("animated") }' \
+  "IPC router exposes picker.animated"
+for t in "${THEMES[@]}"; do
+  assert_contains "$t" 'function animated(): void { ipcOpenPicker("animated") }' "Theme picker handler routes animated"
+done
+
+# ── 2. Capability guard (Omarchy-4 / omarchy-we optional) ────────────────────
+for t in "${THEMES[@]}"; do
+  assert_contains "$t" 'if (theme.wallpaperEngine.checked && !theme.wallpaperEngine.available) return' \
+    "ipcOpenPicker guards animated on capability"
+  assert_contains "$t" 'WallpaperEngineAdapter { id: wallpaperEngineAdapter }' "Theme owns one shared adapter"
+done
+
+# ── 3. Centralized adapter — no duplicated command pipeline in the panels ────
+for a in "${ADAPTERS[@]}"; do
+  [ -f "$a" ] || fail "adapter missing: $a"
+  assert_contains "$a" '"omarchy-we", "ipc", "version"' "adapter probes capability version"
+  assert_contains "$a" 'adapter.contract >= adapter.requiredContract' "adapter enforces version contract"
+  assert_contains "$a" '"omarchy-we", "ipc", "entries"' "adapter owns the entries fetch"
+done
+for p in "${PANELS[@]}"; do
+  assert_absent "$p" 'omarchy-we ipc entries' "panel must not duplicate the entries pipeline"
+  assert_absent "$p" 'omarchy-we ipc current' "panel must not duplicate the current pipeline"
+  assert_contains "$p" 'root.wallpaperEngine.refresh()' "panel delegates animated load to the adapter"
+done
+
+# ── 4. Structured error state (failing/incompatible CLI is not empty) ────────
+for a in "${ADAPTERS[@]}"; do
+  assert_contains "$a" 'if (exitCode !== 0) {' "adapter treats non-zero exit as error"
+  assert_contains "$a" 'adapter.errorText =' "adapter records an error message"
+  assert_contains "$a" 'returned malformed JSON' "adapter reports malformed JSON"
+done
+for p in "${PANELS[@]}"; do
+  assert_contains "$p" 'root.wallpaperEngine.errorText !== ""' "panel shows the adapter error, not empty state"
+done
+
+# ── 5. Safe serialization (sanitize every field) + validation ────────────────
+for a in "${ADAPTERS[@]}"; do
+  assert_contains "$a" '(c < 32) ? " " : t[i]' "adapter strips control chars from fields"
+  assert_contains "$a" 'if (id === "" || preview === "") continue' "adapter validates required fields"
+done
+
+# ── 6. Apply success/failure feedback ────────────────────────────────────────
+for a in "${ADAPTERS[@]}"; do
+  assert_contains "$a" 'adapter.applied(exitCode === 0)' "adapter signals apply success/failure"
+  assert_contains "$a" 'Failed to apply wallpaper' "adapter notifies on a failed apply"
+done
+
+# ── 7. Transition back to static wallpapers stops the renderer ───────────────
+for a in "${ADAPTERS[@]}"; do
+  assert_contains "$a" '"omarchy-we", "ipc", "kill"' "adapter tears down the renderer"
+done
+for p in "${PANELS[@]}"; do
+  # once in the theme branch, once in the static-wallpaper branch
+  assert_count "$p" 'if (root.wallpaperEngine.available) root.wallpaperEngine.stopRenderer()' 2 \
+    "static apply stops the renderer in both theme and wallpaper branches"
+done
+
+# ── 8. Atomic cache replacement (temp file + rename, after validation) ───────
+for a in "${ADAPTERS[@]}"; do
+  assert_contains "$a" 'mv -f' "adapter cache write renames atomically"
+  assert_contains "$a" 'cacheWriteProc.running = true' "adapter writes cache only in the success branch"
+done
+
+# ── 9. V1 / V2 parity for the new + changed picker files ─────────────────────
+for rel in WallpaperEngineAdapter.qml panels/ImageCarouselPanel.qml \
+           panels/ImageCarouselHearthstone.qml panels/ImageCarouselCarousel.qml \
+           panels/ImagePickerModel.js; do
+  cmp -s "$V1/$rel" "$V2/$rel" || fail "V1/V2 diverged: $rel"
+done
+
+printf 'qs-wallpaper-engine regression tests passed\n'

--- a/versions/V1/Theme.qml
+++ b/versions/V1/Theme.qml
@@ -10,6 +10,11 @@ Item {
     property var variantHost: null
     signal reactorTest(string kind, string arg)
 
+    // Wallpaper Engine "animated" picker integration — one adapter shared by all
+    // picker styles (capability probe, entries fetch, apply, renderer teardown).
+    WallpaperEngineAdapter { id: wallpaperEngineAdapter }
+    readonly property alias wallpaperEngine: wallpaperEngineAdapter
+
     property string omarchyCurrentRoot: Quickshell.env("HOME") + "/.config/omarchy/current"
     property string omarchyInstallRoot: Quickshell.env("HOME") + "/.local/share/omarchy"
     property bool omarchyCurrentRootResolved: false
@@ -2487,7 +2492,12 @@ Item {
     }
 
     function ipcOpenPicker(mode) {
-        if (mode === "theme" || mode === "wallpaper" || mode === "animated") openImagePicker(mode)
+        if (mode === "animated") {
+            // Capability guard: no-op when omarchy-we is known to be absent or
+            // incompatible (Omarchy 3.8 / generic Hyprland without the tool).
+            if (theme.wallpaperEngine.checked && !theme.wallpaperEngine.available) return
+            openImagePicker(mode)
+        } else if (mode === "theme" || mode === "wallpaper") openImagePicker(mode)
         else if (mode === "screenshots" || mode === "videos") openMediaBrowser(mode)
     }
 

--- a/versions/V1/Theme.qml
+++ b/versions/V1/Theme.qml
@@ -2487,7 +2487,7 @@ Item {
     }
 
     function ipcOpenPicker(mode) {
-        if (mode === "theme" || mode === "wallpaper") openImagePicker(mode)
+        if (mode === "theme" || mode === "wallpaper" || mode === "animated") openImagePicker(mode)
         else if (mode === "screenshots" || mode === "videos") openMediaBrowser(mode)
     }
 
@@ -2510,6 +2510,7 @@ Item {
             target: "picker"
             function theme(): void { ipcOpenPicker("theme") }
             function wallpaper(): void { ipcOpenPicker("wallpaper") }
+            function animated(): void { ipcOpenPicker("animated") }
             function screenshots(): void { ipcOpenPicker("screenshots") }
             function videos(): void { ipcOpenPicker("videos") }
         }

--- a/versions/V1/WallpaperEngineAdapter.qml
+++ b/versions/V1/WallpaperEngineAdapter.qml
@@ -1,0 +1,185 @@
+pragma ComponentBehavior: Bound
+
+import Quickshell
+import Quickshell.Io
+import QtQuick
+
+// Single owner of all `omarchy-we` interaction for the "animated" (Wallpaper
+// Engine) picker mode. Centralizes the capability probe, entry fetch, JSON
+// validation, atomic caching, error state, apply, and renderer teardown so the
+// three picker styles delegate here instead of each duplicating a shell
+// pipeline.
+//
+// Capability/version contract: `omarchy-we ipc version` must exit 0 and report
+// an `ipc` number >= requiredContract, otherwise the feature stays disabled.
+// See github.com/dkgamer02ai/omarchy-wallpaper-engine.
+QtObject {
+    id: adapter
+
+    // ── capability ──
+    readonly property int requiredContract: 1
+    property bool checked: false      // version probe finished
+    property bool available: false    // omarchy-we present + compatible
+    property int contract: 0
+
+    // ── data (consumed by the picker panels) ──
+    // rowsText is a sanitized "id \t preview \t \t label" feed — every field is
+    // stripped of tabs/newlines/control chars before joining, so no metadata can
+    // corrupt the row format (structured JSON in, safe rows out).
+    property string rowsText: ""
+    property string currentId: ""
+    property bool loading: false
+    property bool loaded: false       // a successful entries fetch populated rowsText
+    property string errorText: ""     // non-empty => last fetch failed (show, don't treat as empty)
+
+    readonly property string cacheDir: Quickshell.env("XDG_CACHE_HOME") || (Quickshell.env("HOME") + "/.cache")
+    readonly property string cachePath: cacheDir + "/quickshell-wallpaper-engine.tsv"
+
+    signal ready()            // rowsText / currentId / errorText updated
+    signal applied(bool ok)   // an apply() finished
+
+    function shq(s) { return "'" + String(s).replace(/'/g, "'\\''") + "'" }
+    function sane(s) {
+        var t = String(s === undefined || s === null ? "" : s)
+        var out = ""
+        for (var i = 0; i < t.length; i++) {
+            var c = t.charCodeAt(i)
+            out += (c < 32) ? " " : t[i]   // drop tabs/newlines/control chars
+        }
+        return out.replace(/ +/g, " ").trim()
+    }
+
+    // Validate + sanitize structured entries into safe TSV rows.
+    function rowsFromEntries(arr) {
+        var out = []
+        for (var i = 0; i < arr.length; i++) {
+            var e = arr[i]
+            if (!e || typeof e !== "object") continue
+            var id = adapter.sane(e.id)
+            var preview = adapter.sane(e.preview)
+            if (id === "" || preview === "") continue        // require id + a preview image
+            var title = adapter.sane(e.title) || id
+            var type = adapter.sane(e.type)
+            var label = type !== "" ? (title + " (" + type + ")") : title
+            out.push(id + "\t" + preview + "\t\t" + label)
+        }
+        return out.join("\n")
+    }
+
+    // ── capability probe ──
+    function checkAvailability() {
+        if (versionProc.running) return
+        versionProc.running = true
+    }
+
+    property Process versionProc: Process {
+        command: ["omarchy-we", "ipc", "version"]
+        stdout: StdioCollector { id: versionOut }
+        onExited: (exitCode) => {
+            adapter.checked = true
+            if (exitCode !== 0) { adapter.available = false; return }
+            try {
+                var d = JSON.parse(String(versionOut.text || "{}"))
+                adapter.contract = Number(d.ipc) || 0
+                adapter.available = adapter.contract >= adapter.requiredContract
+            } catch (e) {
+                adapter.available = false
+            }
+        }
+    }
+
+    // ── load: instant cache paint, then a validated live refresh ──
+    function refresh() {
+        adapter.loading = true
+        currentProc.running = false; currentProc.running = true
+        cacheReadProc.running = false; cacheReadProc.running = true
+        entriesProc.running = false; entriesProc.running = true
+    }
+
+    property Process cacheReadProc: Process {
+        command: ["cat", adapter.cachePath]
+        stdout: StdioCollector { id: cacheOut }
+        onExited: (exitCode) => {
+            // Only paint from cache before the live result lands, and never over an error.
+            if (exitCode === 0 && !adapter.loaded && adapter.errorText === "") {
+                var t = String(cacheOut.text || "").trim()
+                if (t !== "") { adapter.rowsText = t; adapter.ready() }
+            }
+        }
+    }
+
+    property Process currentProc: Process {
+        command: ["omarchy-we", "ipc", "current"]
+        stdout: StdioCollector { id: currentOut }
+        onExited: (exitCode) => {
+            if (exitCode !== 0) return
+            try {
+                var d = JSON.parse(String(currentOut.text || "{}"))
+                adapter.currentId = adapter.sane(d.id)
+                adapter.ready()
+            } catch (e) { /* keep previous currentId */ }
+        }
+    }
+
+    property Process entriesProc: Process {
+        command: ["omarchy-we", "ipc", "entries"]
+        stdout: StdioCollector { id: entriesOut }
+        stderr: StdioCollector { id: entriesErr }
+        onExited: (exitCode) => {
+            adapter.loading = false
+            if (exitCode !== 0) {
+                adapter.errorText = adapter.sane(entriesErr.text) || ("omarchy-we ipc entries failed (exit " + exitCode + ")")
+                adapter.ready()
+                return
+            }
+            var arr
+            try { arr = JSON.parse(String(entriesOut.text || "[]")) }
+            catch (e) { adapter.errorText = "omarchy-we returned malformed JSON"; adapter.ready(); return }
+            if (!Array.isArray(arr)) { adapter.errorText = "omarchy-we returned unexpected data"; adapter.ready(); return }
+
+            adapter.rowsText = adapter.rowsFromEntries(arr)
+            adapter.loaded = true
+            adapter.errorText = ""
+            adapter.ready()
+
+            // Atomic cache replacement: temp file + rename, only after a validated response.
+            cacheWriteProc.command = ["bash", "-c",
+                "d=" + adapter.shq(adapter.cacheDir) + "; mkdir -p \"$d\"; " +
+                "t=" + adapter.shq(adapter.cachePath) + ".$$; " +
+                "printf '%s' \"$1\" > \"$t\" && mv -f \"$t\" " + adapter.shq(adapter.cachePath),
+                "omarchy-we", adapter.rowsText]
+            cacheWriteProc.running = false; cacheWriteProc.running = true
+        }
+    }
+
+    property Process cacheWriteProc: Process { command: [] }
+
+    // ── actions ──
+    function apply(id) {
+        if (!id) return
+        applyProc.command = ["omarchy-we", "ipc", "set", String(id)]
+        applyProc.running = false; applyProc.running = true
+    }
+    property Process applyProc: Process {
+        command: []
+        onExited: (exitCode) => {
+            adapter.applied(exitCode === 0)
+            // A failed `set` would otherwise close the picker silently; surface it.
+            if (exitCode !== 0) {
+                notifyProc.command = ["bash", "-c",
+                    "command -v omarchy-notification-send >/dev/null 2>&1 " +
+                    "&& omarchy-notification-send 'Wallpaper Engine: failed to apply wallpaper' -t 3000 " +
+                    "|| notify-send 'Wallpaper Engine' 'Failed to apply wallpaper' 2>/dev/null || true"]
+                notifyProc.running = false; notifyProc.running = true
+            }
+        }
+    }
+    property Process notifyProc: Process { command: [] }
+
+    // Tear down the renderer when switching back to a static wallpaper. The
+    // caller sets the static background itself, so this only kills the renderer.
+    function stopRenderer() { stopProc.running = false; stopProc.running = true }
+    property Process stopProc: Process { command: ["omarchy-we", "ipc", "kill"] }
+
+    Component.onCompleted: adapter.checkAvailability()
+}

--- a/versions/V1/core/IpcRouter.qml
+++ b/versions/V1/core/IpcRouter.qml
@@ -120,6 +120,7 @@ Item {
         target: "picker"
         function theme(): void { router.openPicker("theme") }
         function wallpaper(): void { router.openPicker("wallpaper") }
+        function animated(): void { router.openPicker("animated") }
         function screenshots(): void { router.openPicker("screenshots") }
         function videos(): void { router.openPicker("videos") }
     }

--- a/versions/V1/panels/ImageCarouselCarousel.qml
+++ b/versions/V1/panels/ImageCarouselCarousel.qml
@@ -59,7 +59,7 @@ PanelWindow {
     // ── open / style gating ──
     function modeKey() { return root.imagePickerMode === "theme" ? "theme" : root.imagePickerMode === "animated" ? "animated" : "wallpaper" }
     function scanCachePathFor(mode) {
-        return Quickshell.env("HOME") + "/.cache/quickshell-scan-" + (mode === "theme" ? "theme" : mode === "animated" ? "animated" : "wallpaper")
+        return Quickshell.env("HOME") + "/.cache/quickshell-scan-" + (mode === "theme" ? "theme" : "wallpaper")
     }
     function saveModeState() {
         if (panel.loadedMode === "theme") {
@@ -130,7 +130,8 @@ PanelWindow {
                     }
                 })
             }
-            panel.startCurrentForMode(mode)
+            if (mode === "animated") root.wallpaperEngine.refresh()
+            else panel.startCurrentForMode(mode)
         } else {
             panel.saveModeState()
             panel.scanDone = false
@@ -143,15 +144,25 @@ PanelWindow {
         function onImagePickerModeChanged()    { panel.syncOpen() }
         function onPickerStyleChanged()         { panel.syncOpen() }
     }
+    // Adopt the adapter's validated rows for the "animated" (Wallpaper Engine)
+    // mode, reusing the same applyScan path as the theme/wallpaper scans.
+    function adoptAnimated() {
+        if (!panel.isAnimatedMode || !panel.active || !root.imagePickerVisible) return
+        panel.currentImage = root.wallpaperEngine.currentId
+        panel.applyScan(root.wallpaperEngine.rowsText, false, "animated")
+    }
+    Connections {
+        target: root.wallpaperEngine
+        enabled: panel.isAnimatedMode
+        function onReady() { panel.adoptAnimated() }
+    }
     Component.onCompleted: panel.syncOpen()
 
     // step 1: current image
     Process {
         id: currentProc
         property string requestMode: "wallpaper"
-        command: requestMode === "animated"
-            ? ["bash", "-c", "omarchy-we ipc current 2>/dev/null | sed -n 's/.*\"id\"[[:space:]]*:[[:space:]]*\"\\([^\"]*\\)\".*/\\1/p'"]
-            : requestMode === "theme"
+        command: requestMode === "theme"
             ? ["bash", "-c",
                "CACHE=$HOME/.cache/quickshell-theme-picker; " +
                "name=$(cat " + panel.shq(root.themeNamePath) + " 2>/dev/null || true); " +
@@ -189,10 +200,6 @@ PanelWindow {
     }
 
     function buildScanCmd(mode) {
-        if (mode === "animated") {
-            // Rows are "id \t preview \t (dir empty) \t label" from omarchy-we.
-            return ["bash", "-c", "omarchy-we ipc entries 2>/dev/null | python3 -c \"import json,sys; arr=json.load(sys.stdin); [print('%s\\t%s\\t\\t%s' % (e.get('id',''), e.get('preview',''), (e.get('title') or e.get('id') or '') + ((' ('+e['type']+')') if e.get('type') else ''))) for e in arr if e.get('preview')]\" 2>/dev/null"]
-        }
         if (mode === "theme") {
             return ["bash", "-c", [
                 "shopt -s nullglob nocaseglob;",
@@ -234,13 +241,14 @@ PanelWindow {
         if (!imagesLoaded || imageArray.length === 0) return
         var path = imageArray[selectedIndex].filePath; if (!path) return
         if (isAnimatedMode) {
-            applyBgProc.command = ["omarchy-we", "ipc", "set", path]
-            applyBgProc.running = false; applyBgProc.running = true
+            root.wallpaperEngine.apply(path)
         } else if (isThemeMode) {
+            if (root.wallpaperEngine.available) root.wallpaperEngine.stopRenderer()
             var name = Model.nameForPath(path)
             applyThemeProc.command = ["env", "OMARCHY_PATH=" + root.omarchyInstallRoot, "omarchy-theme-set", name]
             applyThemeProc.running = false; applyThemeProc.running = true
         } else {
+            if (root.wallpaperEngine.available) root.wallpaperEngine.stopRenderer()
             applyBgProc.command = ["bash", "-c", "omarchy-theme-bg-set '" + path.replace(/'/g, "'\\''") + "'"]
             applyBgProc.running = false; applyBgProc.running = true
         }
@@ -537,7 +545,9 @@ PanelWindow {
         anchors.centerIn: parent
         horizontalAlignment: Text.AlignHCenter
         text: panel.scanDone
-              ? (panel.isAnimatedMode ? "No live wallpapers found" : panel.isThemeMode ? "No themes found" : "No wallpapers found") + "\n\nEsc or click to close"
+              ? (panel.isAnimatedMode
+                    ? (root.wallpaperEngine.errorText !== "" ? root.wallpaperEngine.errorText : "No live wallpapers found")
+                    : panel.isThemeMode ? "No themes found" : "No wallpapers found") + "\n\nEsc or click to close"
               : "Loading…"
         color: root.ink
         style: Text.Outline; styleColor: Qt.rgba(0, 0, 0, 0.6)

--- a/versions/V1/panels/ImageCarouselCarousel.qml
+++ b/versions/V1/panels/ImageCarouselCarousel.qml
@@ -25,6 +25,8 @@ PanelWindow {
 
     readonly property bool active: root.pickerStyle === "carousel"
     readonly property bool isThemeMode: root.imagePickerMode === "theme"
+    // Live Wallpaper Engine wallpapers, sourced from `omarchy-we` (external CLI).
+    readonly property bool isAnimatedMode: root.imagePickerMode === "animated"
     readonly property bool ready: root.imagePickerVisible && active && imagesLoaded && layoutSettled
 
     property bool imagesLoaded:  false
@@ -55,9 +57,9 @@ PanelWindow {
     visible: root.imagePickerVisible && active
 
     // ── open / style gating ──
-    function modeKey() { return root.imagePickerMode === "theme" ? "theme" : "wallpaper" }
+    function modeKey() { return root.imagePickerMode === "theme" ? "theme" : root.imagePickerMode === "animated" ? "animated" : "wallpaper" }
     function scanCachePathFor(mode) {
-        return Quickshell.env("HOME") + "/.cache/quickshell-scan-" + (mode === "theme" ? "theme" : "wallpaper")
+        return Quickshell.env("HOME") + "/.cache/quickshell-scan-" + (mode === "theme" ? "theme" : mode === "animated" ? "animated" : "wallpaper")
     }
     function saveModeState() {
         if (panel.loadedMode === "theme") {
@@ -84,6 +86,15 @@ PanelWindow {
             panel._lastScan = panel.themeLastScan
             panel.imagesLoaded = panel.themeImagesLoaded && panel.imageArray.length > 0
             panel.scanDone = panel.themeScanDone
+        } else if (mode === "animated") {
+            // Animated (Wallpaper Engine) state is not cached per-mode; always
+            // start empty and let the live omarchy-we scan populate it.
+            panel.imageArray = []
+            panel.selectedIndex = 0
+            panel.currentImage = ""
+            panel._lastScan = ""
+            panel.imagesLoaded = false
+            panel.scanDone = false
         } else {
             panel.imageArray = panel.wallpaperImageArray || []
             panel.selectedIndex = Math.max(0, Math.min(panel.wallpaperSelectedIndex, Math.max(0, panel.imageArray.length - 1)))
@@ -138,7 +149,9 @@ PanelWindow {
     Process {
         id: currentProc
         property string requestMode: "wallpaper"
-        command: requestMode === "theme"
+        command: requestMode === "animated"
+            ? ["bash", "-c", "omarchy-we ipc current 2>/dev/null | sed -n 's/.*\"id\"[[:space:]]*:[[:space:]]*\"\\([^\"]*\\)\".*/\\1/p'"]
+            : requestMode === "theme"
             ? ["bash", "-c",
                "CACHE=$HOME/.cache/quickshell-theme-picker; " +
                "name=$(cat " + panel.shq(root.themeNamePath) + " 2>/dev/null || true); " +
@@ -176,6 +189,10 @@ PanelWindow {
     }
 
     function buildScanCmd(mode) {
+        if (mode === "animated") {
+            // Rows are "id \t preview \t (dir empty) \t label" from omarchy-we.
+            return ["bash", "-c", "omarchy-we ipc entries 2>/dev/null | python3 -c \"import json,sys; arr=json.load(sys.stdin); [print('%s\\t%s\\t\\t%s' % (e.get('id',''), e.get('preview',''), (e.get('title') or e.get('id') or '') + ((' ('+e['type']+')') if e.get('type') else ''))) for e in arr if e.get('preview')]\" 2>/dev/null"]
+        }
         if (mode === "theme") {
             return ["bash", "-c", [
                 "shopt -s nullglob nocaseglob;",
@@ -216,7 +233,10 @@ PanelWindow {
     function applySelected() {
         if (!imagesLoaded || imageArray.length === 0) return
         var path = imageArray[selectedIndex].filePath; if (!path) return
-        if (isThemeMode) {
+        if (isAnimatedMode) {
+            applyBgProc.command = ["omarchy-we", "ipc", "set", path]
+            applyBgProc.running = false; applyBgProc.running = true
+        } else if (isThemeMode) {
             var name = Model.nameForPath(path)
             applyThemeProc.command = ["env", "OMARCHY_PATH=" + root.omarchyInstallRoot, "omarchy-theme-set", name]
             applyThemeProc.running = false; applyThemeProc.running = true
@@ -238,7 +258,7 @@ PanelWindow {
 
     function currentLabel() {
         if (imageArray.length === 0 || !Model.itemMatches(imageArray, selectedIndex, filterText)) return filterText ? "No matches" : ""
-        return Model.labelForPath(imageArray[selectedIndex].filePath)
+        return imageArray[selectedIndex].label || Model.labelForPath(imageArray[selectedIndex].filePath)
     }
 
     function filteredPos(idx)  { return Model.filteredPosition(imageArray, idx, filterText) }
@@ -517,7 +537,7 @@ PanelWindow {
         anchors.centerIn: parent
         horizontalAlignment: Text.AlignHCenter
         text: panel.scanDone
-              ? (panel.isThemeMode ? "No themes found" : "No wallpapers found") + "\n\nEsc or click to close"
+              ? (panel.isAnimatedMode ? "No live wallpapers found" : panel.isThemeMode ? "No themes found" : "No wallpapers found") + "\n\nEsc or click to close"
               : "Loading…"
         color: root.ink
         style: Text.Outline; styleColor: Qt.rgba(0, 0, 0, 0.6)

--- a/versions/V1/panels/ImageCarouselHearthstone.qml
+++ b/versions/V1/panels/ImageCarouselHearthstone.qml
@@ -87,7 +87,8 @@ PanelWindow {
                 panel.selFilt       = 0
                 panel.reveal        = 0
                 panel.dealT         = 0
-                currentProc.running = false; currentProc.running = true
+                if (panel.isAnimatedMode) root.wallpaperEngine.refresh()
+                else { currentProc.running = false; currentProc.running = true }
             }
         } else {
             panel.imagesLoaded  = false; panel.scanDone = false
@@ -96,19 +97,30 @@ PanelWindow {
             panel.dealT         = 0
         }
     }
+    // Adopt the adapter's validated rows for the "animated" (Wallpaper Engine)
+    // mode, reusing the same applyScan path as the theme/wallpaper scans.
+    function adoptAnimated() {
+        if (!panel.isAnimatedMode || !panel.active || !root.imagePickerVisible) return
+        panel.currentImage = root.wallpaperEngine.currentId
+        panel.applyScan(root.wallpaperEngine.rowsText, false)
+    }
     Connections {
         target: root
         function onImagePickerVisibleChanged() { panel.syncOpen() }
+        function onImagePickerModeChanged()     { panel.syncOpen() }
         function onPickerStyleChanged()         { panel.syncOpen() }
+    }
+    Connections {
+        target: root.wallpaperEngine
+        enabled: panel.isAnimatedMode
+        function onReady() { panel.adoptAnimated() }
     }
     Component.onCompleted: panel.syncOpen()
 
     // step 1: current image
     Process {
         id: currentProc
-        command: panel.isAnimatedMode
-            ? ["bash", "-c", "omarchy-we ipc current 2>/dev/null | sed -n 's/.*\"id\"[[:space:]]*:[[:space:]]*\"\\([^\"]*\\)\".*/\\1/p'"]
-            : panel.isThemeMode
+        command: panel.isThemeMode
             ? ["bash", "-c",
                "CACHE=$HOME/.cache/quickshell-theme-picker; " +
                "name=$(cat " + panel.shq(root.themeNamePath) + " 2>/dev/null || true); " +
@@ -138,7 +150,7 @@ PanelWindow {
     }
 
     // scan-result cache → instant (re)open (shared cache file with the other theme styles)
-    readonly property string scanCachePath: Quickshell.env("HOME") + "/.cache/quickshell-scan-" + (isAnimatedMode ? "animated" : isThemeMode ? "theme" : "wallpaper")
+    readonly property string scanCachePath: Quickshell.env("HOME") + "/.cache/quickshell-scan-" + (isThemeMode ? "theme" : "wallpaper")
     property string _lastScan: ""
     function scanHasOriginalThumbs(text) {
         var rows = String(text || "").split("\n")
@@ -177,10 +189,6 @@ PanelWindow {
     }
 
     function buildScanCmd() {
-        if (isAnimatedMode) {
-            // Rows are "id \t preview \t (dir empty) \t label" from omarchy-we.
-            return ["bash", "-c", "omarchy-we ipc entries 2>/dev/null | python3 -c \"import json,sys; arr=json.load(sys.stdin); [print('%s\\t%s\\t\\t%s' % (e.get('id',''), e.get('preview',''), (e.get('title') or e.get('id') or '') + ((' ('+e['type']+')') if e.get('type') else ''))) for e in arr if e.get('preview')]\" 2>/dev/null"]
-        }
         if (isThemeMode) {
             return ["bash", "-c", [
                 "shopt -s nullglob nocaseglob;",
@@ -223,13 +231,14 @@ PanelWindow {
         if (selFilt < 0 || selFilt >= filtered.length) return
         var path = filtered[selFilt].filePath; if (!path) return
         if (isAnimatedMode) {
-            applyBgProc.command = ["omarchy-we", "ipc", "set", path]
-            applyBgProc.running = false; applyBgProc.running = true
+            root.wallpaperEngine.apply(path)
         } else if (isThemeMode) {
+            if (root.wallpaperEngine.available) root.wallpaperEngine.stopRenderer()
             var name = Model.nameForPath(path)
             applyThemeProc.command = ["env", "OMARCHY_PATH=" + root.omarchyInstallRoot, "omarchy-theme-set", name]
             applyThemeProc.running = false; applyThemeProc.running = true
         } else {
+            if (root.wallpaperEngine.available) root.wallpaperEngine.stopRenderer()
             applyBgProc.command = ["bash", "-c", "omarchy-theme-bg-set '" + path.replace(/'/g, "'\\''") + "'"]
             applyBgProc.running = false; applyBgProc.running = true
         }
@@ -460,7 +469,9 @@ PanelWindow {
         anchors.centerIn: parent
         horizontalAlignment: Text.AlignHCenter
         text: panel.scanDone
-              ? (panel.isAnimatedMode ? "No live wallpapers found" : panel.isThemeMode ? "No themes found" : "No wallpapers found") + "\n\nEsc or click to close"
+              ? (panel.isAnimatedMode
+                    ? (root.wallpaperEngine.errorText !== "" ? root.wallpaperEngine.errorText : "No live wallpapers found")
+                    : panel.isThemeMode ? "No themes found" : "No wallpapers found") + "\n\nEsc or click to close"
               : "Loading…"
         color: panel.textLight
         font.family: root.mono; font.pixelSize: 16; font.letterSpacing: 1

--- a/versions/V1/panels/ImageCarouselHearthstone.qml
+++ b/versions/V1/panels/ImageCarouselHearthstone.qml
@@ -24,6 +24,8 @@ PanelWindow {
 
     readonly property bool active: root.pickerStyle === "hearthstone"
     readonly property bool isThemeMode: root.imagePickerMode === "theme"
+    // Live Wallpaper Engine wallpapers, sourced from `omarchy-we` (external CLI).
+    readonly property bool isAnimatedMode: root.imagePickerMode === "animated"
     readonly property bool ready: root.imagePickerVisible && active && imagesLoaded && layoutSettled
 
     property bool imagesLoaded:  false
@@ -57,7 +59,7 @@ PanelWindow {
                 idx:      i,
                 filePath: imageArray[i].filePath,
                 thumb:    panel.thumbUrlFor(imageArray[i]),
-                label:    Model.labelForPath(imageArray[i].filePath),
+                label:    imageArray[i].label || Model.labelForPath(imageArray[i].filePath),
                 dir:      imageArray[i].dir || "",
                 current:  imageArray[i].filePath === panel.currentImage
             })
@@ -104,7 +106,9 @@ PanelWindow {
     // step 1: current image
     Process {
         id: currentProc
-        command: panel.isThemeMode
+        command: panel.isAnimatedMode
+            ? ["bash", "-c", "omarchy-we ipc current 2>/dev/null | sed -n 's/.*\"id\"[[:space:]]*:[[:space:]]*\"\\([^\"]*\\)\".*/\\1/p'"]
+            : panel.isThemeMode
             ? ["bash", "-c",
                "CACHE=$HOME/.cache/quickshell-theme-picker; " +
                "name=$(cat " + panel.shq(root.themeNamePath) + " 2>/dev/null || true); " +
@@ -134,7 +138,7 @@ PanelWindow {
     }
 
     // scan-result cache → instant (re)open (shared cache file with the other theme styles)
-    readonly property string scanCachePath: Quickshell.env("HOME") + "/.cache/quickshell-scan-" + (isThemeMode ? "theme" : "wallpaper")
+    readonly property string scanCachePath: Quickshell.env("HOME") + "/.cache/quickshell-scan-" + (isAnimatedMode ? "animated" : isThemeMode ? "theme" : "wallpaper")
     property string _lastScan: ""
     function scanHasOriginalThumbs(text) {
         var rows = String(text || "").split("\n")
@@ -173,6 +177,10 @@ PanelWindow {
     }
 
     function buildScanCmd() {
+        if (isAnimatedMode) {
+            // Rows are "id \t preview \t (dir empty) \t label" from omarchy-we.
+            return ["bash", "-c", "omarchy-we ipc entries 2>/dev/null | python3 -c \"import json,sys; arr=json.load(sys.stdin); [print('%s\\t%s\\t\\t%s' % (e.get('id',''), e.get('preview',''), (e.get('title') or e.get('id') or '') + ((' ('+e['type']+')') if e.get('type') else ''))) for e in arr if e.get('preview')]\" 2>/dev/null"]
+        }
         if (isThemeMode) {
             return ["bash", "-c", [
                 "shopt -s nullglob nocaseglob;",
@@ -214,7 +222,10 @@ PanelWindow {
         if (!imagesLoaded || filtered.length === 0) return
         if (selFilt < 0 || selFilt >= filtered.length) return
         var path = filtered[selFilt].filePath; if (!path) return
-        if (isThemeMode) {
+        if (isAnimatedMode) {
+            applyBgProc.command = ["omarchy-we", "ipc", "set", path]
+            applyBgProc.running = false; applyBgProc.running = true
+        } else if (isThemeMode) {
             var name = Model.nameForPath(path)
             applyThemeProc.command = ["env", "OMARCHY_PATH=" + root.omarchyInstallRoot, "omarchy-theme-set", name]
             applyThemeProc.running = false; applyThemeProc.running = true
@@ -449,7 +460,7 @@ PanelWindow {
         anchors.centerIn: parent
         horizontalAlignment: Text.AlignHCenter
         text: panel.scanDone
-              ? (panel.isThemeMode ? "No themes found" : "No wallpapers found") + "\n\nEsc or click to close"
+              ? (panel.isAnimatedMode ? "No live wallpapers found" : panel.isThemeMode ? "No themes found" : "No wallpapers found") + "\n\nEsc or click to close"
               : "Loading…"
         color: panel.textLight
         font.family: root.mono; font.pixelSize: 16; font.letterSpacing: 1
@@ -461,7 +472,7 @@ PanelWindow {
         anchors.horizontalCenter: parent.horizontalCenter
         anchors.top: parent.top; anchors.topMargin: 40
         opacity: panel.reveal
-        text: (panel.isThemeMode ? "THEME" : "WALLPAPER") + "      " + (panel.selFilt + 1) + " / " + panel.filtered.length
+        text: (panel.isAnimatedMode ? "LIVE WALLPAPER" : panel.isThemeMode ? "THEME" : "WALLPAPER") + "      " + (panel.selFilt + 1) + " / " + panel.filtered.length
         color: panel.textDim
         font.family: root.mono; font.pixelSize: 12; font.letterSpacing: 2
     }

--- a/versions/V1/panels/ImageCarouselPanel.qml
+++ b/versions/V1/panels/ImageCarouselPanel.qml
@@ -81,7 +81,8 @@ PanelWindow {
                 panel.imageArray    = []
                 panel.selFilt       = 0
                 panel.reveal        = 0
-                currentProc.running = false; currentProc.running = true
+                if (panel.isAnimatedMode) root.wallpaperEngine.refresh()
+                else { currentProc.running = false; currentProc.running = true }
             }
         } else {
             panel.imagesLoaded  = false; panel.scanDone = false
@@ -89,19 +90,30 @@ PanelWindow {
             panel.reveal        = 0
         }
     }
+    // Adopt the adapter's validated rows for the "animated" (Wallpaper Engine)
+    // mode, reusing the same applyScan path as the theme/wallpaper scans.
+    function adoptAnimated() {
+        if (!panel.isAnimatedMode || !panel.active || !root.imagePickerVisible) return
+        panel.currentImage = root.wallpaperEngine.currentId
+        panel.applyScan(root.wallpaperEngine.rowsText, false)
+    }
     Connections {
         target: root
         function onImagePickerVisibleChanged() { panel.syncOpen() }
+        function onImagePickerModeChanged()     { panel.syncOpen() }
         function onPickerStyleChanged()         { panel.syncOpen() }
+    }
+    Connections {
+        target: root.wallpaperEngine
+        enabled: panel.isAnimatedMode
+        function onReady() { panel.adoptAnimated() }
     }
     Component.onCompleted: panel.syncOpen()
 
     // step 1: current image
     Process {
         id: currentProc
-        command: panel.isAnimatedMode
-            ? ["bash", "-c", "omarchy-we ipc current 2>/dev/null | sed -n 's/.*\"id\"[[:space:]]*:[[:space:]]*\"\\([^\"]*\\)\".*/\\1/p'"]
-            : panel.isThemeMode
+        command: panel.isThemeMode
             ? ["bash", "-c",
                "CACHE=$HOME/.cache/quickshell-theme-picker; " +
                "name=$(cat " + panel.shq(root.themeNamePath) + " 2>/dev/null || true); " +
@@ -131,7 +143,7 @@ PanelWindow {
     }
 
     // scan-result cache → instant (re)open
-    readonly property string scanCachePath: Quickshell.env("HOME") + "/.cache/quickshell-scan-" + (isAnimatedMode ? "animated" : isThemeMode ? "theme" : "wallpaper")
+    readonly property string scanCachePath: Quickshell.env("HOME") + "/.cache/quickshell-scan-" + (isThemeMode ? "theme" : "wallpaper")
     property string _lastScan: ""
     function scanHasOriginalThumbs(text) {
         var rows = String(text || "").split("\n")
@@ -170,10 +182,6 @@ PanelWindow {
     }
 
     function buildScanCmd() {
-        if (isAnimatedMode) {
-            // Rows are "id \t preview \t (dir empty) \t label" from omarchy-we.
-            return ["bash", "-c", "omarchy-we ipc entries 2>/dev/null | python3 -c \"import json,sys; arr=json.load(sys.stdin); [print('%s\\t%s\\t\\t%s' % (e.get('id',''), e.get('preview',''), (e.get('title') or e.get('id') or '') + ((' ('+e['type']+')') if e.get('type') else ''))) for e in arr if e.get('preview')]\" 2>/dev/null"]
-        }
         if (isThemeMode) {
             return ["bash", "-c", [
                 "shopt -s nullglob nocaseglob;",
@@ -216,13 +224,14 @@ PanelWindow {
         if (selFilt < 0 || selFilt >= filtered.length) return
         var path = filtered[selFilt].filePath; if (!path) return
         if (isAnimatedMode) {
-            applyBgProc.command = ["omarchy-we", "ipc", "set", path]
-            applyBgProc.running = false; applyBgProc.running = true
+            root.wallpaperEngine.apply(path)
         } else if (isThemeMode) {
+            if (root.wallpaperEngine.available) root.wallpaperEngine.stopRenderer()
             var name = Model.nameForPath(path)
             applyThemeProc.command = ["env", "OMARCHY_PATH=" + root.omarchyInstallRoot, "omarchy-theme-set", name]
             applyThemeProc.running = false; applyThemeProc.running = true
         } else {
+            if (root.wallpaperEngine.available) root.wallpaperEngine.stopRenderer()
             applyBgProc.command = ["bash", "-c", "omarchy-theme-bg-set '" + path.replace(/'/g, "'\\''") + "'"]
             applyBgProc.running = false; applyBgProc.running = true
         }
@@ -462,7 +471,9 @@ PanelWindow {
         anchors.centerIn: parent
         horizontalAlignment: Text.AlignHCenter
         text: panel.scanDone
-              ? (panel.isAnimatedMode ? "No live wallpapers found" : panel.isThemeMode ? "No themes found" : "No wallpapers found") + "\n\nEsc or click to close"
+              ? (panel.isAnimatedMode
+                    ? (root.wallpaperEngine.errorText !== "" ? root.wallpaperEngine.errorText : "No live wallpapers found")
+                    : panel.isThemeMode ? "No themes found" : "No wallpapers found") + "\n\nEsc or click to close"
               : "Loading…"
         color: root.ink
         font.family: root.mono; font.pixelSize: 16; font.letterSpacing: 1

--- a/versions/V1/panels/ImageCarouselPanel.qml
+++ b/versions/V1/panels/ImageCarouselPanel.qml
@@ -24,6 +24,8 @@ PanelWindow {
 
     readonly property bool active: root.pickerStyle === "tanzaku" || root.pickerStyle === ""   // default
     readonly property bool isThemeMode: root.imagePickerMode === "theme"
+    // Live Wallpaper Engine wallpapers, sourced from `omarchy-we` (external CLI).
+    readonly property bool isAnimatedMode: root.imagePickerMode === "animated"
     readonly property bool ready: root.imagePickerVisible && active && imagesLoaded && layoutSettled
 
     property bool imagesLoaded:  false
@@ -52,7 +54,7 @@ PanelWindow {
                 idx:      i,
                 filePath: imageArray[i].filePath,
                 thumb:    panel.thumbUrlFor(imageArray[i]),
-                label:    Model.labelForPath(imageArray[i].filePath),
+                label:    imageArray[i].label || Model.labelForPath(imageArray[i].filePath),
                 dir:      imageArray[i].dir || "",
                 current:  imageArray[i].filePath === panel.currentImage
             })
@@ -97,7 +99,9 @@ PanelWindow {
     // step 1: current image
     Process {
         id: currentProc
-        command: panel.isThemeMode
+        command: panel.isAnimatedMode
+            ? ["bash", "-c", "omarchy-we ipc current 2>/dev/null | sed -n 's/.*\"id\"[[:space:]]*:[[:space:]]*\"\\([^\"]*\\)\".*/\\1/p'"]
+            : panel.isThemeMode
             ? ["bash", "-c",
                "CACHE=$HOME/.cache/quickshell-theme-picker; " +
                "name=$(cat " + panel.shq(root.themeNamePath) + " 2>/dev/null || true); " +
@@ -127,7 +131,7 @@ PanelWindow {
     }
 
     // scan-result cache → instant (re)open
-    readonly property string scanCachePath: Quickshell.env("HOME") + "/.cache/quickshell-scan-" + (isThemeMode ? "theme" : "wallpaper")
+    readonly property string scanCachePath: Quickshell.env("HOME") + "/.cache/quickshell-scan-" + (isAnimatedMode ? "animated" : isThemeMode ? "theme" : "wallpaper")
     property string _lastScan: ""
     function scanHasOriginalThumbs(text) {
         var rows = String(text || "").split("\n")
@@ -166,6 +170,10 @@ PanelWindow {
     }
 
     function buildScanCmd() {
+        if (isAnimatedMode) {
+            // Rows are "id \t preview \t (dir empty) \t label" from omarchy-we.
+            return ["bash", "-c", "omarchy-we ipc entries 2>/dev/null | python3 -c \"import json,sys; arr=json.load(sys.stdin); [print('%s\\t%s\\t\\t%s' % (e.get('id',''), e.get('preview',''), (e.get('title') or e.get('id') or '') + ((' ('+e['type']+')') if e.get('type') else ''))) for e in arr if e.get('preview')]\" 2>/dev/null"]
+        }
         if (isThemeMode) {
             return ["bash", "-c", [
                 "shopt -s nullglob nocaseglob;",
@@ -207,7 +215,10 @@ PanelWindow {
         if (!imagesLoaded || filtered.length === 0) return
         if (selFilt < 0 || selFilt >= filtered.length) return
         var path = filtered[selFilt].filePath; if (!path) return
-        if (isThemeMode) {
+        if (isAnimatedMode) {
+            applyBgProc.command = ["omarchy-we", "ipc", "set", path]
+            applyBgProc.running = false; applyBgProc.running = true
+        } else if (isThemeMode) {
             var name = Model.nameForPath(path)
             applyThemeProc.command = ["env", "OMARCHY_PATH=" + root.omarchyInstallRoot, "omarchy-theme-set", name]
             applyThemeProc.running = false; applyThemeProc.running = true
@@ -451,7 +462,7 @@ PanelWindow {
         anchors.centerIn: parent
         horizontalAlignment: Text.AlignHCenter
         text: panel.scanDone
-              ? (panel.isThemeMode ? "No themes found" : "No wallpapers found") + "\n\nEsc or click to close"
+              ? (panel.isAnimatedMode ? "No live wallpapers found" : panel.isThemeMode ? "No themes found" : "No wallpapers found") + "\n\nEsc or click to close"
               : "Loading…"
         color: root.ink
         font.family: root.mono; font.pixelSize: 16; font.letterSpacing: 1
@@ -464,7 +475,7 @@ PanelWindow {
         anchors.bottom: stage.top
         anchors.bottomMargin: 22
         opacity: panel.reveal
-        text: panel.isThemeMode ? "THEME" : "WALLPAPER"
+        text: panel.isAnimatedMode ? "LIVE WALLPAPER" : panel.isThemeMode ? "THEME" : "WALLPAPER"
         color: root.sumiHi
         font.family: root.mono; font.pixelSize: 12; font.letterSpacing: 3; font.weight: Font.Medium
         horizontalAlignment: Text.AlignHCenter

--- a/versions/V1/panels/ImagePickerModel.js
+++ b/versions/V1/panels/ImagePickerModel.js
@@ -17,7 +17,10 @@ function loadRows(rows) {
       thumbnailPath: columns[1] || path,
       // optional 3rd column (theme scan only): the theme directory, used to
       // lazily fetch author/palette for the focused theme without slowing the scan
-      dir: columns[2] || ""
+      dir: columns[2] || "",
+      // optional 4th column (animated / Wallpaper Engine scan only): display
+      // label shown instead of the file-name-derived label
+      label: columns[3] || ""
     })
   }
   return images
@@ -26,8 +29,10 @@ function itemMatches(images, index, filterText) {
   if (!Array.isArray(images) || index < 0 || index >= images.length) return false
   var needle = String(filterText || "").toLowerCase(); if (!needle) return true
   var path = String(images[index].filePath || "")
+  var extra = String(images[index].label || "")
   return nameForPath(path).toLowerCase().indexOf(needle) !== -1
       || labelForPath(path).toLowerCase().indexOf(needle) !== -1
+      || (extra !== "" && extra.toLowerCase().indexOf(needle) !== -1)
 }
 function matchCount(images, filterText) {
   if (!Array.isArray(images)) return 0

--- a/versions/V1/variants/V2/Theme.qml
+++ b/versions/V1/variants/V2/Theme.qml
@@ -9,6 +9,11 @@ Item {
     id: theme
     property var variantHost: null
 
+    // Wallpaper Engine "animated" picker integration — one adapter shared by all
+    // picker styles (capability probe, entries fetch, apply, renderer teardown).
+    WallpaperEngineAdapter { id: wallpaperEngineAdapter }
+    readonly property alias wallpaperEngine: wallpaperEngineAdapter
+
     property string omarchyCurrentRoot: Quickshell.env("HOME") + "/.config/omarchy/current"
     property string omarchyInstallRoot: Quickshell.env("HOME") + "/.local/share/omarchy"
     property bool omarchyCurrentRootResolved: false
@@ -3202,7 +3207,12 @@ Item {
     }
 
     function ipcOpenPicker(mode) {
-        if (mode === "theme" || mode === "wallpaper" || mode === "animated") openImagePicker(mode)
+        if (mode === "animated") {
+            // Capability guard: no-op when omarchy-we is known to be absent or
+            // incompatible (Omarchy 3.8 / generic Hyprland without the tool).
+            if (theme.wallpaperEngine.checked && !theme.wallpaperEngine.available) return
+            openImagePicker(mode)
+        } else if (mode === "theme" || mode === "wallpaper") openImagePicker(mode)
         else if (mode === "screenshots" || mode === "videos") openMediaBrowser(mode)
     }
 

--- a/versions/V1/variants/V2/Theme.qml
+++ b/versions/V1/variants/V2/Theme.qml
@@ -3202,7 +3202,7 @@ Item {
     }
 
     function ipcOpenPicker(mode) {
-        if (mode === "theme" || mode === "wallpaper") openImagePicker(mode)
+        if (mode === "theme" || mode === "wallpaper" || mode === "animated") openImagePicker(mode)
         else if (mode === "screenshots" || mode === "videos") openMediaBrowser(mode)
     }
 
@@ -3225,6 +3225,7 @@ Item {
             target: "picker"
             function theme(): void { ipcOpenPicker("theme") }
             function wallpaper(): void { ipcOpenPicker("wallpaper") }
+            function animated(): void { ipcOpenPicker("animated") }
             function screenshots(): void { ipcOpenPicker("screenshots") }
             function videos(): void { ipcOpenPicker("videos") }
         }

--- a/versions/V1/variants/V2/WallpaperEngineAdapter.qml
+++ b/versions/V1/variants/V2/WallpaperEngineAdapter.qml
@@ -1,0 +1,185 @@
+pragma ComponentBehavior: Bound
+
+import Quickshell
+import Quickshell.Io
+import QtQuick
+
+// Single owner of all `omarchy-we` interaction for the "animated" (Wallpaper
+// Engine) picker mode. Centralizes the capability probe, entry fetch, JSON
+// validation, atomic caching, error state, apply, and renderer teardown so the
+// three picker styles delegate here instead of each duplicating a shell
+// pipeline.
+//
+// Capability/version contract: `omarchy-we ipc version` must exit 0 and report
+// an `ipc` number >= requiredContract, otherwise the feature stays disabled.
+// See github.com/dkgamer02ai/omarchy-wallpaper-engine.
+QtObject {
+    id: adapter
+
+    // ── capability ──
+    readonly property int requiredContract: 1
+    property bool checked: false      // version probe finished
+    property bool available: false    // omarchy-we present + compatible
+    property int contract: 0
+
+    // ── data (consumed by the picker panels) ──
+    // rowsText is a sanitized "id \t preview \t \t label" feed — every field is
+    // stripped of tabs/newlines/control chars before joining, so no metadata can
+    // corrupt the row format (structured JSON in, safe rows out).
+    property string rowsText: ""
+    property string currentId: ""
+    property bool loading: false
+    property bool loaded: false       // a successful entries fetch populated rowsText
+    property string errorText: ""     // non-empty => last fetch failed (show, don't treat as empty)
+
+    readonly property string cacheDir: Quickshell.env("XDG_CACHE_HOME") || (Quickshell.env("HOME") + "/.cache")
+    readonly property string cachePath: cacheDir + "/quickshell-wallpaper-engine.tsv"
+
+    signal ready()            // rowsText / currentId / errorText updated
+    signal applied(bool ok)   // an apply() finished
+
+    function shq(s) { return "'" + String(s).replace(/'/g, "'\\''") + "'" }
+    function sane(s) {
+        var t = String(s === undefined || s === null ? "" : s)
+        var out = ""
+        for (var i = 0; i < t.length; i++) {
+            var c = t.charCodeAt(i)
+            out += (c < 32) ? " " : t[i]   // drop tabs/newlines/control chars
+        }
+        return out.replace(/ +/g, " ").trim()
+    }
+
+    // Validate + sanitize structured entries into safe TSV rows.
+    function rowsFromEntries(arr) {
+        var out = []
+        for (var i = 0; i < arr.length; i++) {
+            var e = arr[i]
+            if (!e || typeof e !== "object") continue
+            var id = adapter.sane(e.id)
+            var preview = adapter.sane(e.preview)
+            if (id === "" || preview === "") continue        // require id + a preview image
+            var title = adapter.sane(e.title) || id
+            var type = adapter.sane(e.type)
+            var label = type !== "" ? (title + " (" + type + ")") : title
+            out.push(id + "\t" + preview + "\t\t" + label)
+        }
+        return out.join("\n")
+    }
+
+    // ── capability probe ──
+    function checkAvailability() {
+        if (versionProc.running) return
+        versionProc.running = true
+    }
+
+    property Process versionProc: Process {
+        command: ["omarchy-we", "ipc", "version"]
+        stdout: StdioCollector { id: versionOut }
+        onExited: (exitCode) => {
+            adapter.checked = true
+            if (exitCode !== 0) { adapter.available = false; return }
+            try {
+                var d = JSON.parse(String(versionOut.text || "{}"))
+                adapter.contract = Number(d.ipc) || 0
+                adapter.available = adapter.contract >= adapter.requiredContract
+            } catch (e) {
+                adapter.available = false
+            }
+        }
+    }
+
+    // ── load: instant cache paint, then a validated live refresh ──
+    function refresh() {
+        adapter.loading = true
+        currentProc.running = false; currentProc.running = true
+        cacheReadProc.running = false; cacheReadProc.running = true
+        entriesProc.running = false; entriesProc.running = true
+    }
+
+    property Process cacheReadProc: Process {
+        command: ["cat", adapter.cachePath]
+        stdout: StdioCollector { id: cacheOut }
+        onExited: (exitCode) => {
+            // Only paint from cache before the live result lands, and never over an error.
+            if (exitCode === 0 && !adapter.loaded && adapter.errorText === "") {
+                var t = String(cacheOut.text || "").trim()
+                if (t !== "") { adapter.rowsText = t; adapter.ready() }
+            }
+        }
+    }
+
+    property Process currentProc: Process {
+        command: ["omarchy-we", "ipc", "current"]
+        stdout: StdioCollector { id: currentOut }
+        onExited: (exitCode) => {
+            if (exitCode !== 0) return
+            try {
+                var d = JSON.parse(String(currentOut.text || "{}"))
+                adapter.currentId = adapter.sane(d.id)
+                adapter.ready()
+            } catch (e) { /* keep previous currentId */ }
+        }
+    }
+
+    property Process entriesProc: Process {
+        command: ["omarchy-we", "ipc", "entries"]
+        stdout: StdioCollector { id: entriesOut }
+        stderr: StdioCollector { id: entriesErr }
+        onExited: (exitCode) => {
+            adapter.loading = false
+            if (exitCode !== 0) {
+                adapter.errorText = adapter.sane(entriesErr.text) || ("omarchy-we ipc entries failed (exit " + exitCode + ")")
+                adapter.ready()
+                return
+            }
+            var arr
+            try { arr = JSON.parse(String(entriesOut.text || "[]")) }
+            catch (e) { adapter.errorText = "omarchy-we returned malformed JSON"; adapter.ready(); return }
+            if (!Array.isArray(arr)) { adapter.errorText = "omarchy-we returned unexpected data"; adapter.ready(); return }
+
+            adapter.rowsText = adapter.rowsFromEntries(arr)
+            adapter.loaded = true
+            adapter.errorText = ""
+            adapter.ready()
+
+            // Atomic cache replacement: temp file + rename, only after a validated response.
+            cacheWriteProc.command = ["bash", "-c",
+                "d=" + adapter.shq(adapter.cacheDir) + "; mkdir -p \"$d\"; " +
+                "t=" + adapter.shq(adapter.cachePath) + ".$$; " +
+                "printf '%s' \"$1\" > \"$t\" && mv -f \"$t\" " + adapter.shq(adapter.cachePath),
+                "omarchy-we", adapter.rowsText]
+            cacheWriteProc.running = false; cacheWriteProc.running = true
+        }
+    }
+
+    property Process cacheWriteProc: Process { command: [] }
+
+    // ── actions ──
+    function apply(id) {
+        if (!id) return
+        applyProc.command = ["omarchy-we", "ipc", "set", String(id)]
+        applyProc.running = false; applyProc.running = true
+    }
+    property Process applyProc: Process {
+        command: []
+        onExited: (exitCode) => {
+            adapter.applied(exitCode === 0)
+            // A failed `set` would otherwise close the picker silently; surface it.
+            if (exitCode !== 0) {
+                notifyProc.command = ["bash", "-c",
+                    "command -v omarchy-notification-send >/dev/null 2>&1 " +
+                    "&& omarchy-notification-send 'Wallpaper Engine: failed to apply wallpaper' -t 3000 " +
+                    "|| notify-send 'Wallpaper Engine' 'Failed to apply wallpaper' 2>/dev/null || true"]
+                notifyProc.running = false; notifyProc.running = true
+            }
+        }
+    }
+    property Process notifyProc: Process { command: [] }
+
+    // Tear down the renderer when switching back to a static wallpaper. The
+    // caller sets the static background itself, so this only kills the renderer.
+    function stopRenderer() { stopProc.running = false; stopProc.running = true }
+    property Process stopProc: Process { command: ["omarchy-we", "ipc", "kill"] }
+
+    Component.onCompleted: adapter.checkAvailability()
+}

--- a/versions/V1/variants/V2/panels/ImageCarouselCarousel.qml
+++ b/versions/V1/variants/V2/panels/ImageCarouselCarousel.qml
@@ -59,7 +59,7 @@ PanelWindow {
     // ── open / style gating ──
     function modeKey() { return root.imagePickerMode === "theme" ? "theme" : root.imagePickerMode === "animated" ? "animated" : "wallpaper" }
     function scanCachePathFor(mode) {
-        return Quickshell.env("HOME") + "/.cache/quickshell-scan-" + (mode === "theme" ? "theme" : mode === "animated" ? "animated" : "wallpaper")
+        return Quickshell.env("HOME") + "/.cache/quickshell-scan-" + (mode === "theme" ? "theme" : "wallpaper")
     }
     function saveModeState() {
         if (panel.loadedMode === "theme") {
@@ -130,7 +130,8 @@ PanelWindow {
                     }
                 })
             }
-            panel.startCurrentForMode(mode)
+            if (mode === "animated") root.wallpaperEngine.refresh()
+            else panel.startCurrentForMode(mode)
         } else {
             panel.saveModeState()
             panel.scanDone = false
@@ -143,15 +144,25 @@ PanelWindow {
         function onImagePickerModeChanged()    { panel.syncOpen() }
         function onPickerStyleChanged()         { panel.syncOpen() }
     }
+    // Adopt the adapter's validated rows for the "animated" (Wallpaper Engine)
+    // mode, reusing the same applyScan path as the theme/wallpaper scans.
+    function adoptAnimated() {
+        if (!panel.isAnimatedMode || !panel.active || !root.imagePickerVisible) return
+        panel.currentImage = root.wallpaperEngine.currentId
+        panel.applyScan(root.wallpaperEngine.rowsText, false, "animated")
+    }
+    Connections {
+        target: root.wallpaperEngine
+        enabled: panel.isAnimatedMode
+        function onReady() { panel.adoptAnimated() }
+    }
     Component.onCompleted: panel.syncOpen()
 
     // step 1: current image
     Process {
         id: currentProc
         property string requestMode: "wallpaper"
-        command: requestMode === "animated"
-            ? ["bash", "-c", "omarchy-we ipc current 2>/dev/null | sed -n 's/.*\"id\"[[:space:]]*:[[:space:]]*\"\\([^\"]*\\)\".*/\\1/p'"]
-            : requestMode === "theme"
+        command: requestMode === "theme"
             ? ["bash", "-c",
                "CACHE=$HOME/.cache/quickshell-theme-picker; " +
                "name=$(cat " + panel.shq(root.themeNamePath) + " 2>/dev/null || true); " +
@@ -189,10 +200,6 @@ PanelWindow {
     }
 
     function buildScanCmd(mode) {
-        if (mode === "animated") {
-            // Rows are "id \t preview \t (dir empty) \t label" from omarchy-we.
-            return ["bash", "-c", "omarchy-we ipc entries 2>/dev/null | python3 -c \"import json,sys; arr=json.load(sys.stdin); [print('%s\\t%s\\t\\t%s' % (e.get('id',''), e.get('preview',''), (e.get('title') or e.get('id') or '') + ((' ('+e['type']+')') if e.get('type') else ''))) for e in arr if e.get('preview')]\" 2>/dev/null"]
-        }
         if (mode === "theme") {
             return ["bash", "-c", [
                 "shopt -s nullglob nocaseglob;",
@@ -234,13 +241,14 @@ PanelWindow {
         if (!imagesLoaded || imageArray.length === 0) return
         var path = imageArray[selectedIndex].filePath; if (!path) return
         if (isAnimatedMode) {
-            applyBgProc.command = ["omarchy-we", "ipc", "set", path]
-            applyBgProc.running = false; applyBgProc.running = true
+            root.wallpaperEngine.apply(path)
         } else if (isThemeMode) {
+            if (root.wallpaperEngine.available) root.wallpaperEngine.stopRenderer()
             var name = Model.nameForPath(path)
             applyThemeProc.command = ["env", "OMARCHY_PATH=" + root.omarchyInstallRoot, "omarchy-theme-set", name]
             applyThemeProc.running = false; applyThemeProc.running = true
         } else {
+            if (root.wallpaperEngine.available) root.wallpaperEngine.stopRenderer()
             applyBgProc.command = ["bash", "-c", "omarchy-theme-bg-set '" + path.replace(/'/g, "'\\''") + "'"]
             applyBgProc.running = false; applyBgProc.running = true
         }
@@ -537,7 +545,9 @@ PanelWindow {
         anchors.centerIn: parent
         horizontalAlignment: Text.AlignHCenter
         text: panel.scanDone
-              ? (panel.isAnimatedMode ? "No live wallpapers found" : panel.isThemeMode ? "No themes found" : "No wallpapers found") + "\n\nEsc or click to close"
+              ? (panel.isAnimatedMode
+                    ? (root.wallpaperEngine.errorText !== "" ? root.wallpaperEngine.errorText : "No live wallpapers found")
+                    : panel.isThemeMode ? "No themes found" : "No wallpapers found") + "\n\nEsc or click to close"
               : "Loading…"
         color: root.ink
         style: Text.Outline; styleColor: Qt.rgba(0, 0, 0, 0.6)

--- a/versions/V1/variants/V2/panels/ImageCarouselCarousel.qml
+++ b/versions/V1/variants/V2/panels/ImageCarouselCarousel.qml
@@ -25,6 +25,8 @@ PanelWindow {
 
     readonly property bool active: root.pickerStyle === "carousel"
     readonly property bool isThemeMode: root.imagePickerMode === "theme"
+    // Live Wallpaper Engine wallpapers, sourced from `omarchy-we` (external CLI).
+    readonly property bool isAnimatedMode: root.imagePickerMode === "animated"
     readonly property bool ready: root.imagePickerVisible && active && imagesLoaded && layoutSettled
 
     property bool imagesLoaded:  false
@@ -55,9 +57,9 @@ PanelWindow {
     visible: root.imagePickerVisible && active
 
     // ── open / style gating ──
-    function modeKey() { return root.imagePickerMode === "theme" ? "theme" : "wallpaper" }
+    function modeKey() { return root.imagePickerMode === "theme" ? "theme" : root.imagePickerMode === "animated" ? "animated" : "wallpaper" }
     function scanCachePathFor(mode) {
-        return Quickshell.env("HOME") + "/.cache/quickshell-scan-" + (mode === "theme" ? "theme" : "wallpaper")
+        return Quickshell.env("HOME") + "/.cache/quickshell-scan-" + (mode === "theme" ? "theme" : mode === "animated" ? "animated" : "wallpaper")
     }
     function saveModeState() {
         if (panel.loadedMode === "theme") {
@@ -84,6 +86,15 @@ PanelWindow {
             panel._lastScan = panel.themeLastScan
             panel.imagesLoaded = panel.themeImagesLoaded && panel.imageArray.length > 0
             panel.scanDone = panel.themeScanDone
+        } else if (mode === "animated") {
+            // Animated (Wallpaper Engine) state is not cached per-mode; always
+            // start empty and let the live omarchy-we scan populate it.
+            panel.imageArray = []
+            panel.selectedIndex = 0
+            panel.currentImage = ""
+            panel._lastScan = ""
+            panel.imagesLoaded = false
+            panel.scanDone = false
         } else {
             panel.imageArray = panel.wallpaperImageArray || []
             panel.selectedIndex = Math.max(0, Math.min(panel.wallpaperSelectedIndex, Math.max(0, panel.imageArray.length - 1)))
@@ -138,7 +149,9 @@ PanelWindow {
     Process {
         id: currentProc
         property string requestMode: "wallpaper"
-        command: requestMode === "theme"
+        command: requestMode === "animated"
+            ? ["bash", "-c", "omarchy-we ipc current 2>/dev/null | sed -n 's/.*\"id\"[[:space:]]*:[[:space:]]*\"\\([^\"]*\\)\".*/\\1/p'"]
+            : requestMode === "theme"
             ? ["bash", "-c",
                "CACHE=$HOME/.cache/quickshell-theme-picker; " +
                "name=$(cat " + panel.shq(root.themeNamePath) + " 2>/dev/null || true); " +
@@ -176,6 +189,10 @@ PanelWindow {
     }
 
     function buildScanCmd(mode) {
+        if (mode === "animated") {
+            // Rows are "id \t preview \t (dir empty) \t label" from omarchy-we.
+            return ["bash", "-c", "omarchy-we ipc entries 2>/dev/null | python3 -c \"import json,sys; arr=json.load(sys.stdin); [print('%s\\t%s\\t\\t%s' % (e.get('id',''), e.get('preview',''), (e.get('title') or e.get('id') or '') + ((' ('+e['type']+')') if e.get('type') else ''))) for e in arr if e.get('preview')]\" 2>/dev/null"]
+        }
         if (mode === "theme") {
             return ["bash", "-c", [
                 "shopt -s nullglob nocaseglob;",
@@ -216,7 +233,10 @@ PanelWindow {
     function applySelected() {
         if (!imagesLoaded || imageArray.length === 0) return
         var path = imageArray[selectedIndex].filePath; if (!path) return
-        if (isThemeMode) {
+        if (isAnimatedMode) {
+            applyBgProc.command = ["omarchy-we", "ipc", "set", path]
+            applyBgProc.running = false; applyBgProc.running = true
+        } else if (isThemeMode) {
             var name = Model.nameForPath(path)
             applyThemeProc.command = ["env", "OMARCHY_PATH=" + root.omarchyInstallRoot, "omarchy-theme-set", name]
             applyThemeProc.running = false; applyThemeProc.running = true
@@ -238,7 +258,7 @@ PanelWindow {
 
     function currentLabel() {
         if (imageArray.length === 0 || !Model.itemMatches(imageArray, selectedIndex, filterText)) return filterText ? "No matches" : ""
-        return Model.labelForPath(imageArray[selectedIndex].filePath)
+        return imageArray[selectedIndex].label || Model.labelForPath(imageArray[selectedIndex].filePath)
     }
 
     function filteredPos(idx)  { return Model.filteredPosition(imageArray, idx, filterText) }
@@ -517,7 +537,7 @@ PanelWindow {
         anchors.centerIn: parent
         horizontalAlignment: Text.AlignHCenter
         text: panel.scanDone
-              ? (panel.isThemeMode ? "No themes found" : "No wallpapers found") + "\n\nEsc or click to close"
+              ? (panel.isAnimatedMode ? "No live wallpapers found" : panel.isThemeMode ? "No themes found" : "No wallpapers found") + "\n\nEsc or click to close"
               : "Loading…"
         color: root.ink
         style: Text.Outline; styleColor: Qt.rgba(0, 0, 0, 0.6)

--- a/versions/V1/variants/V2/panels/ImageCarouselHearthstone.qml
+++ b/versions/V1/variants/V2/panels/ImageCarouselHearthstone.qml
@@ -87,7 +87,8 @@ PanelWindow {
                 panel.selFilt       = 0
                 panel.reveal        = 0
                 panel.dealT         = 0
-                currentProc.running = false; currentProc.running = true
+                if (panel.isAnimatedMode) root.wallpaperEngine.refresh()
+                else { currentProc.running = false; currentProc.running = true }
             }
         } else {
             panel.imagesLoaded  = false; panel.scanDone = false
@@ -96,19 +97,30 @@ PanelWindow {
             panel.dealT         = 0
         }
     }
+    // Adopt the adapter's validated rows for the "animated" (Wallpaper Engine)
+    // mode, reusing the same applyScan path as the theme/wallpaper scans.
+    function adoptAnimated() {
+        if (!panel.isAnimatedMode || !panel.active || !root.imagePickerVisible) return
+        panel.currentImage = root.wallpaperEngine.currentId
+        panel.applyScan(root.wallpaperEngine.rowsText, false)
+    }
     Connections {
         target: root
         function onImagePickerVisibleChanged() { panel.syncOpen() }
+        function onImagePickerModeChanged()     { panel.syncOpen() }
         function onPickerStyleChanged()         { panel.syncOpen() }
+    }
+    Connections {
+        target: root.wallpaperEngine
+        enabled: panel.isAnimatedMode
+        function onReady() { panel.adoptAnimated() }
     }
     Component.onCompleted: panel.syncOpen()
 
     // step 1: current image
     Process {
         id: currentProc
-        command: panel.isAnimatedMode
-            ? ["bash", "-c", "omarchy-we ipc current 2>/dev/null | sed -n 's/.*\"id\"[[:space:]]*:[[:space:]]*\"\\([^\"]*\\)\".*/\\1/p'"]
-            : panel.isThemeMode
+        command: panel.isThemeMode
             ? ["bash", "-c",
                "CACHE=$HOME/.cache/quickshell-theme-picker; " +
                "name=$(cat " + panel.shq(root.themeNamePath) + " 2>/dev/null || true); " +
@@ -138,7 +150,7 @@ PanelWindow {
     }
 
     // scan-result cache → instant (re)open (shared cache file with the other theme styles)
-    readonly property string scanCachePath: Quickshell.env("HOME") + "/.cache/quickshell-scan-" + (isAnimatedMode ? "animated" : isThemeMode ? "theme" : "wallpaper")
+    readonly property string scanCachePath: Quickshell.env("HOME") + "/.cache/quickshell-scan-" + (isThemeMode ? "theme" : "wallpaper")
     property string _lastScan: ""
     function scanHasOriginalThumbs(text) {
         var rows = String(text || "").split("\n")
@@ -177,10 +189,6 @@ PanelWindow {
     }
 
     function buildScanCmd() {
-        if (isAnimatedMode) {
-            // Rows are "id \t preview \t (dir empty) \t label" from omarchy-we.
-            return ["bash", "-c", "omarchy-we ipc entries 2>/dev/null | python3 -c \"import json,sys; arr=json.load(sys.stdin); [print('%s\\t%s\\t\\t%s' % (e.get('id',''), e.get('preview',''), (e.get('title') or e.get('id') or '') + ((' ('+e['type']+')') if e.get('type') else ''))) for e in arr if e.get('preview')]\" 2>/dev/null"]
-        }
         if (isThemeMode) {
             return ["bash", "-c", [
                 "shopt -s nullglob nocaseglob;",
@@ -223,13 +231,14 @@ PanelWindow {
         if (selFilt < 0 || selFilt >= filtered.length) return
         var path = filtered[selFilt].filePath; if (!path) return
         if (isAnimatedMode) {
-            applyBgProc.command = ["omarchy-we", "ipc", "set", path]
-            applyBgProc.running = false; applyBgProc.running = true
+            root.wallpaperEngine.apply(path)
         } else if (isThemeMode) {
+            if (root.wallpaperEngine.available) root.wallpaperEngine.stopRenderer()
             var name = Model.nameForPath(path)
             applyThemeProc.command = ["env", "OMARCHY_PATH=" + root.omarchyInstallRoot, "omarchy-theme-set", name]
             applyThemeProc.running = false; applyThemeProc.running = true
         } else {
+            if (root.wallpaperEngine.available) root.wallpaperEngine.stopRenderer()
             applyBgProc.command = ["bash", "-c", "omarchy-theme-bg-set '" + path.replace(/'/g, "'\\''") + "'"]
             applyBgProc.running = false; applyBgProc.running = true
         }
@@ -460,7 +469,9 @@ PanelWindow {
         anchors.centerIn: parent
         horizontalAlignment: Text.AlignHCenter
         text: panel.scanDone
-              ? (panel.isAnimatedMode ? "No live wallpapers found" : panel.isThemeMode ? "No themes found" : "No wallpapers found") + "\n\nEsc or click to close"
+              ? (panel.isAnimatedMode
+                    ? (root.wallpaperEngine.errorText !== "" ? root.wallpaperEngine.errorText : "No live wallpapers found")
+                    : panel.isThemeMode ? "No themes found" : "No wallpapers found") + "\n\nEsc or click to close"
               : "Loading…"
         color: panel.textLight
         font.family: root.mono; font.pixelSize: 16; font.letterSpacing: 1

--- a/versions/V1/variants/V2/panels/ImageCarouselHearthstone.qml
+++ b/versions/V1/variants/V2/panels/ImageCarouselHearthstone.qml
@@ -24,6 +24,8 @@ PanelWindow {
 
     readonly property bool active: root.pickerStyle === "hearthstone"
     readonly property bool isThemeMode: root.imagePickerMode === "theme"
+    // Live Wallpaper Engine wallpapers, sourced from `omarchy-we` (external CLI).
+    readonly property bool isAnimatedMode: root.imagePickerMode === "animated"
     readonly property bool ready: root.imagePickerVisible && active && imagesLoaded && layoutSettled
 
     property bool imagesLoaded:  false
@@ -57,7 +59,7 @@ PanelWindow {
                 idx:      i,
                 filePath: imageArray[i].filePath,
                 thumb:    panel.thumbUrlFor(imageArray[i]),
-                label:    Model.labelForPath(imageArray[i].filePath),
+                label:    imageArray[i].label || Model.labelForPath(imageArray[i].filePath),
                 dir:      imageArray[i].dir || "",
                 current:  imageArray[i].filePath === panel.currentImage
             })
@@ -104,7 +106,9 @@ PanelWindow {
     // step 1: current image
     Process {
         id: currentProc
-        command: panel.isThemeMode
+        command: panel.isAnimatedMode
+            ? ["bash", "-c", "omarchy-we ipc current 2>/dev/null | sed -n 's/.*\"id\"[[:space:]]*:[[:space:]]*\"\\([^\"]*\\)\".*/\\1/p'"]
+            : panel.isThemeMode
             ? ["bash", "-c",
                "CACHE=$HOME/.cache/quickshell-theme-picker; " +
                "name=$(cat " + panel.shq(root.themeNamePath) + " 2>/dev/null || true); " +
@@ -134,7 +138,7 @@ PanelWindow {
     }
 
     // scan-result cache → instant (re)open (shared cache file with the other theme styles)
-    readonly property string scanCachePath: Quickshell.env("HOME") + "/.cache/quickshell-scan-" + (isThemeMode ? "theme" : "wallpaper")
+    readonly property string scanCachePath: Quickshell.env("HOME") + "/.cache/quickshell-scan-" + (isAnimatedMode ? "animated" : isThemeMode ? "theme" : "wallpaper")
     property string _lastScan: ""
     function scanHasOriginalThumbs(text) {
         var rows = String(text || "").split("\n")
@@ -173,6 +177,10 @@ PanelWindow {
     }
 
     function buildScanCmd() {
+        if (isAnimatedMode) {
+            // Rows are "id \t preview \t (dir empty) \t label" from omarchy-we.
+            return ["bash", "-c", "omarchy-we ipc entries 2>/dev/null | python3 -c \"import json,sys; arr=json.load(sys.stdin); [print('%s\\t%s\\t\\t%s' % (e.get('id',''), e.get('preview',''), (e.get('title') or e.get('id') or '') + ((' ('+e['type']+')') if e.get('type') else ''))) for e in arr if e.get('preview')]\" 2>/dev/null"]
+        }
         if (isThemeMode) {
             return ["bash", "-c", [
                 "shopt -s nullglob nocaseglob;",
@@ -214,7 +222,10 @@ PanelWindow {
         if (!imagesLoaded || filtered.length === 0) return
         if (selFilt < 0 || selFilt >= filtered.length) return
         var path = filtered[selFilt].filePath; if (!path) return
-        if (isThemeMode) {
+        if (isAnimatedMode) {
+            applyBgProc.command = ["omarchy-we", "ipc", "set", path]
+            applyBgProc.running = false; applyBgProc.running = true
+        } else if (isThemeMode) {
             var name = Model.nameForPath(path)
             applyThemeProc.command = ["env", "OMARCHY_PATH=" + root.omarchyInstallRoot, "omarchy-theme-set", name]
             applyThemeProc.running = false; applyThemeProc.running = true
@@ -449,7 +460,7 @@ PanelWindow {
         anchors.centerIn: parent
         horizontalAlignment: Text.AlignHCenter
         text: panel.scanDone
-              ? (panel.isThemeMode ? "No themes found" : "No wallpapers found") + "\n\nEsc or click to close"
+              ? (panel.isAnimatedMode ? "No live wallpapers found" : panel.isThemeMode ? "No themes found" : "No wallpapers found") + "\n\nEsc or click to close"
               : "Loading…"
         color: panel.textLight
         font.family: root.mono; font.pixelSize: 16; font.letterSpacing: 1
@@ -461,7 +472,7 @@ PanelWindow {
         anchors.horizontalCenter: parent.horizontalCenter
         anchors.top: parent.top; anchors.topMargin: 40
         opacity: panel.reveal
-        text: (panel.isThemeMode ? "THEME" : "WALLPAPER") + "      " + (panel.selFilt + 1) + " / " + panel.filtered.length
+        text: (panel.isAnimatedMode ? "LIVE WALLPAPER" : panel.isThemeMode ? "THEME" : "WALLPAPER") + "      " + (panel.selFilt + 1) + " / " + panel.filtered.length
         color: panel.textDim
         font.family: root.mono; font.pixelSize: 12; font.letterSpacing: 2
     }

--- a/versions/V1/variants/V2/panels/ImageCarouselPanel.qml
+++ b/versions/V1/variants/V2/panels/ImageCarouselPanel.qml
@@ -81,7 +81,8 @@ PanelWindow {
                 panel.imageArray    = []
                 panel.selFilt       = 0
                 panel.reveal        = 0
-                currentProc.running = false; currentProc.running = true
+                if (panel.isAnimatedMode) root.wallpaperEngine.refresh()
+                else { currentProc.running = false; currentProc.running = true }
             }
         } else {
             panel.imagesLoaded  = false; panel.scanDone = false
@@ -89,19 +90,30 @@ PanelWindow {
             panel.reveal        = 0
         }
     }
+    // Adopt the adapter's validated rows for the "animated" (Wallpaper Engine)
+    // mode, reusing the same applyScan path as the theme/wallpaper scans.
+    function adoptAnimated() {
+        if (!panel.isAnimatedMode || !panel.active || !root.imagePickerVisible) return
+        panel.currentImage = root.wallpaperEngine.currentId
+        panel.applyScan(root.wallpaperEngine.rowsText, false)
+    }
     Connections {
         target: root
         function onImagePickerVisibleChanged() { panel.syncOpen() }
+        function onImagePickerModeChanged()     { panel.syncOpen() }
         function onPickerStyleChanged()         { panel.syncOpen() }
+    }
+    Connections {
+        target: root.wallpaperEngine
+        enabled: panel.isAnimatedMode
+        function onReady() { panel.adoptAnimated() }
     }
     Component.onCompleted: panel.syncOpen()
 
     // step 1: current image
     Process {
         id: currentProc
-        command: panel.isAnimatedMode
-            ? ["bash", "-c", "omarchy-we ipc current 2>/dev/null | sed -n 's/.*\"id\"[[:space:]]*:[[:space:]]*\"\\([^\"]*\\)\".*/\\1/p'"]
-            : panel.isThemeMode
+        command: panel.isThemeMode
             ? ["bash", "-c",
                "CACHE=$HOME/.cache/quickshell-theme-picker; " +
                "name=$(cat " + panel.shq(root.themeNamePath) + " 2>/dev/null || true); " +
@@ -131,7 +143,7 @@ PanelWindow {
     }
 
     // scan-result cache → instant (re)open
-    readonly property string scanCachePath: Quickshell.env("HOME") + "/.cache/quickshell-scan-" + (isAnimatedMode ? "animated" : isThemeMode ? "theme" : "wallpaper")
+    readonly property string scanCachePath: Quickshell.env("HOME") + "/.cache/quickshell-scan-" + (isThemeMode ? "theme" : "wallpaper")
     property string _lastScan: ""
     function scanHasOriginalThumbs(text) {
         var rows = String(text || "").split("\n")
@@ -170,10 +182,6 @@ PanelWindow {
     }
 
     function buildScanCmd() {
-        if (isAnimatedMode) {
-            // Rows are "id \t preview \t (dir empty) \t label" from omarchy-we.
-            return ["bash", "-c", "omarchy-we ipc entries 2>/dev/null | python3 -c \"import json,sys; arr=json.load(sys.stdin); [print('%s\\t%s\\t\\t%s' % (e.get('id',''), e.get('preview',''), (e.get('title') or e.get('id') or '') + ((' ('+e['type']+')') if e.get('type') else ''))) for e in arr if e.get('preview')]\" 2>/dev/null"]
-        }
         if (isThemeMode) {
             return ["bash", "-c", [
                 "shopt -s nullglob nocaseglob;",
@@ -216,13 +224,14 @@ PanelWindow {
         if (selFilt < 0 || selFilt >= filtered.length) return
         var path = filtered[selFilt].filePath; if (!path) return
         if (isAnimatedMode) {
-            applyBgProc.command = ["omarchy-we", "ipc", "set", path]
-            applyBgProc.running = false; applyBgProc.running = true
+            root.wallpaperEngine.apply(path)
         } else if (isThemeMode) {
+            if (root.wallpaperEngine.available) root.wallpaperEngine.stopRenderer()
             var name = Model.nameForPath(path)
             applyThemeProc.command = ["env", "OMARCHY_PATH=" + root.omarchyInstallRoot, "omarchy-theme-set", name]
             applyThemeProc.running = false; applyThemeProc.running = true
         } else {
+            if (root.wallpaperEngine.available) root.wallpaperEngine.stopRenderer()
             applyBgProc.command = ["bash", "-c", "omarchy-theme-bg-set '" + path.replace(/'/g, "'\\''") + "'"]
             applyBgProc.running = false; applyBgProc.running = true
         }
@@ -462,7 +471,9 @@ PanelWindow {
         anchors.centerIn: parent
         horizontalAlignment: Text.AlignHCenter
         text: panel.scanDone
-              ? (panel.isAnimatedMode ? "No live wallpapers found" : panel.isThemeMode ? "No themes found" : "No wallpapers found") + "\n\nEsc or click to close"
+              ? (panel.isAnimatedMode
+                    ? (root.wallpaperEngine.errorText !== "" ? root.wallpaperEngine.errorText : "No live wallpapers found")
+                    : panel.isThemeMode ? "No themes found" : "No wallpapers found") + "\n\nEsc or click to close"
               : "Loading…"
         color: root.ink
         font.family: root.mono; font.pixelSize: 16; font.letterSpacing: 1

--- a/versions/V1/variants/V2/panels/ImageCarouselPanel.qml
+++ b/versions/V1/variants/V2/panels/ImageCarouselPanel.qml
@@ -24,6 +24,8 @@ PanelWindow {
 
     readonly property bool active: root.pickerStyle === "tanzaku" || root.pickerStyle === ""   // default
     readonly property bool isThemeMode: root.imagePickerMode === "theme"
+    // Live Wallpaper Engine wallpapers, sourced from `omarchy-we` (external CLI).
+    readonly property bool isAnimatedMode: root.imagePickerMode === "animated"
     readonly property bool ready: root.imagePickerVisible && active && imagesLoaded && layoutSettled
 
     property bool imagesLoaded:  false
@@ -52,7 +54,7 @@ PanelWindow {
                 idx:      i,
                 filePath: imageArray[i].filePath,
                 thumb:    panel.thumbUrlFor(imageArray[i]),
-                label:    Model.labelForPath(imageArray[i].filePath),
+                label:    imageArray[i].label || Model.labelForPath(imageArray[i].filePath),
                 dir:      imageArray[i].dir || "",
                 current:  imageArray[i].filePath === panel.currentImage
             })
@@ -97,7 +99,9 @@ PanelWindow {
     // step 1: current image
     Process {
         id: currentProc
-        command: panel.isThemeMode
+        command: panel.isAnimatedMode
+            ? ["bash", "-c", "omarchy-we ipc current 2>/dev/null | sed -n 's/.*\"id\"[[:space:]]*:[[:space:]]*\"\\([^\"]*\\)\".*/\\1/p'"]
+            : panel.isThemeMode
             ? ["bash", "-c",
                "CACHE=$HOME/.cache/quickshell-theme-picker; " +
                "name=$(cat " + panel.shq(root.themeNamePath) + " 2>/dev/null || true); " +
@@ -127,7 +131,7 @@ PanelWindow {
     }
 
     // scan-result cache → instant (re)open
-    readonly property string scanCachePath: Quickshell.env("HOME") + "/.cache/quickshell-scan-" + (isThemeMode ? "theme" : "wallpaper")
+    readonly property string scanCachePath: Quickshell.env("HOME") + "/.cache/quickshell-scan-" + (isAnimatedMode ? "animated" : isThemeMode ? "theme" : "wallpaper")
     property string _lastScan: ""
     function scanHasOriginalThumbs(text) {
         var rows = String(text || "").split("\n")
@@ -166,6 +170,10 @@ PanelWindow {
     }
 
     function buildScanCmd() {
+        if (isAnimatedMode) {
+            // Rows are "id \t preview \t (dir empty) \t label" from omarchy-we.
+            return ["bash", "-c", "omarchy-we ipc entries 2>/dev/null | python3 -c \"import json,sys; arr=json.load(sys.stdin); [print('%s\\t%s\\t\\t%s' % (e.get('id',''), e.get('preview',''), (e.get('title') or e.get('id') or '') + ((' ('+e['type']+')') if e.get('type') else ''))) for e in arr if e.get('preview')]\" 2>/dev/null"]
+        }
         if (isThemeMode) {
             return ["bash", "-c", [
                 "shopt -s nullglob nocaseglob;",
@@ -207,7 +215,10 @@ PanelWindow {
         if (!imagesLoaded || filtered.length === 0) return
         if (selFilt < 0 || selFilt >= filtered.length) return
         var path = filtered[selFilt].filePath; if (!path) return
-        if (isThemeMode) {
+        if (isAnimatedMode) {
+            applyBgProc.command = ["omarchy-we", "ipc", "set", path]
+            applyBgProc.running = false; applyBgProc.running = true
+        } else if (isThemeMode) {
             var name = Model.nameForPath(path)
             applyThemeProc.command = ["env", "OMARCHY_PATH=" + root.omarchyInstallRoot, "omarchy-theme-set", name]
             applyThemeProc.running = false; applyThemeProc.running = true
@@ -451,7 +462,7 @@ PanelWindow {
         anchors.centerIn: parent
         horizontalAlignment: Text.AlignHCenter
         text: panel.scanDone
-              ? (panel.isThemeMode ? "No themes found" : "No wallpapers found") + "\n\nEsc or click to close"
+              ? (panel.isAnimatedMode ? "No live wallpapers found" : panel.isThemeMode ? "No themes found" : "No wallpapers found") + "\n\nEsc or click to close"
               : "Loading…"
         color: root.ink
         font.family: root.mono; font.pixelSize: 16; font.letterSpacing: 1
@@ -464,7 +475,7 @@ PanelWindow {
         anchors.bottom: stage.top
         anchors.bottomMargin: 22
         opacity: panel.reveal
-        text: panel.isThemeMode ? "THEME" : "WALLPAPER"
+        text: panel.isAnimatedMode ? "LIVE WALLPAPER" : panel.isThemeMode ? "THEME" : "WALLPAPER"
         color: root.sumiHi
         font.family: root.mono; font.pixelSize: 12; font.letterSpacing: 3; font.weight: Font.Medium
         horizontalAlignment: Text.AlignHCenter

--- a/versions/V1/variants/V2/panels/ImagePickerModel.js
+++ b/versions/V1/variants/V2/panels/ImagePickerModel.js
@@ -17,7 +17,10 @@ function loadRows(rows) {
       thumbnailPath: columns[1] || path,
       // optional 3rd column (theme scan only): the theme directory, used to
       // lazily fetch author/palette for the focused theme without slowing the scan
-      dir: columns[2] || ""
+      dir: columns[2] || "",
+      // optional 4th column (animated / Wallpaper Engine scan only): display
+      // label shown instead of the file-name-derived label
+      label: columns[3] || ""
     })
   }
   return images
@@ -26,8 +29,10 @@ function itemMatches(images, index, filterText) {
   if (!Array.isArray(images) || index < 0 || index >= images.length) return false
   var needle = String(filterText || "").toLowerCase(); if (!needle) return true
   var path = String(images[index].filePath || "")
+  var extra = String(images[index].label || "")
   return nameForPath(path).toLowerCase().indexOf(needle) !== -1
       || labelForPath(path).toLowerCase().indexOf(needle) !== -1
+      || (extra !== "" && extra.toLowerCase().indexOf(needle) !== -1)
 }
 function matchCount(images, filterText) {
   if (!Array.isArray(images)) return 0


### PR DESCRIPTION
## What

Adds a third image-picker mode — `animated` — alongside the existing
`theme` and `wallpaper` modes. It lists **live Wallpaper Engine wallpapers**
and applies them, reusing the existing filmstrip picker UI (all three styles).

Wallpaper logic is delegated to the external **`omarchy-we`** CLI
([dkgamer02ai/omarchy-wallpaper-engine](https://github.com/dkgamer02ai/omarchy-wallpaper-engine)),
which renders Steam Workshop scene/video wallpapers via `linux-wallpaperengine`.
The bar only talks to its small IPC surface.

## How to use

qs-barctl ipc picker animated

(bind a key to it, same as the theme/wallpaper pickers). Requires `omarchy-we`
on `PATH`.

## Changes

- **IpcRouter / Theme**: new `picker animated` route → `ipcOpenPicker("animated")`
  (`ipcOpenPicker` now accepts the animated mode).
- **ImagePickerModel.js**: optional 4th scan column = display label, and
  `itemMatches` filters on it — so entries keyed by numeric Workshop id still
  show titles and are searchable by title.
- **All three picker styles** (tanzaku / hearthstone / carousel), **V1 and V2**:
  - scan → `omarchy-we ipc entries`, mapped to `id \t preview \t \t label`
  - current → `omarchy-we ipc current`
  - apply → `omarchy-we ipc set <id>`
  - separate scan cache (`quickshell-scan-animated`); own header / empty-state labels.
  - carousel: `modeKey`/`scanCachePathFor`/`restoreModeState` handle the new mode.

## Contract (`omarchy-we ipc`)

- `entries` → JSON array `[{id, title, type, preview, current}]`
- `current` → JSON `{id, title, type, preview, running}`
- `set <id>` → apply by Workshop id

## Testing

- `qmllint`: **0 errors** on all changed files.
- `tests/qs-theme-update-regression.sh`: **passes** (image-picker contract pins intact).
- V1 and V2 copies kept **byte-identical**.
- **Live-tested**: hearthstone (V2) confirmed working end-to-end (grid populated
  from `omarchy-we`, selection applies). tanzaku/carousel share the identical
  pipeline but weren't individually run live yet.

## Notes

- The `animated` mode is inert unless `omarchy-we` is installed (empty grid /
  no-op), so it's safe for users without Wallpaper Engine.
- No changes to the theme/wallpaper code paths.