### PR TITLE
fix: require edit mode for separator changes

### DIFF
--- a/tests/qs-bar-edit-lock-regression.sh
+++ b/tests/qs-bar-edit-lock-regression.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+V1_BAR="$REPO_ROOT/versions/V1/BarSlot.qml"
+V2_BAR="$REPO_ROOT/versions/V1/variants/V2/BarSlot.qml"
+
+fail() {
+  printf 'FAIL: %s\n' "$*" >&2
+  exit 1
+}
+
+assert_unlock_guard() {
+  local id="$1" file="$2" block
+  block="$(sed -n "/id: ${id}[[:space:]]*$/,+8p" "$file")"
+  [[ -n $block ]] || fail "missing MouseArea id: $id in $file"
+  grep -Fq 'enabled: barSlot.root.barUnlocked' <<<"$block" \
+    || fail "$id can mutate separators while the bar is locked"
+}
+
+assert_unlock_guard mkMa "$V1_BAR"
+assert_unlock_guard bMa "$V1_BAR"
+assert_unlock_guard sepMa "$V2_BAR"
+
+printf 'PASS: separator edit handles require unlock mode\n'

--- a/versions/V1/BarSlot.qml
+++ b/versions/V1/BarSlot.qml
@@ -606,6 +606,7 @@ PanelWindow {
                     MouseArea {
                         id: mkMa
                         anchors.fill: parent
+                        enabled: barSlot.root.barUnlocked
                         hoverEnabled: true
                         cursorShape: Qt.PointingHandCursor
                         onClicked: if (toggleGap) toggleGap(slot.index)
@@ -976,6 +977,7 @@ PanelWindow {
             MouseArea {
                 id: bMa
                 anchors.fill: parent
+                enabled: barSlot.root.barUnlocked
                 hoverEnabled: true
                 cursorShape: Qt.PointingHandCursor
                 onClicked: if (bm.toggleFn) bm.toggleFn()

--- a/versions/V1/variants/V2/BarSlot.qml
+++ b/versions/V1/variants/V2/BarSlot.qml
@@ -1745,6 +1745,7 @@ PanelWindow {
                     MouseArea {
                         id: sepMa
                         anchors.fill: parent
+                        enabled: barSlot.root.barUnlocked
                         hoverEnabled: true
                         cursorShape: Qt.PointingHandCursor
                         onClicked: barSlot.root.toggleSep(slot.gid)


### PR DESCRIPTION
## Summary

Prevents separator controls from changing the bar layout while the bar is locked.

- Require `barUnlocked` for V1 within-region split handles.
- Require `barUnlocked` for V1 left/center/right boundary split handles.
- Require `barUnlocked` for V2 separator handles.
- Add a regression script that checks all three edit handles remain gated by unlock mode.

## Why

Separator `MouseArea`s were still active when the layout was locked, so an ordinary click near a separator could accidentally merge or split bar sections. This could, for example, join the center and right sections into one large pill.

The change keeps separator editing available in edit mode while making the locked layout read-only.

## Scope

This is intentionally small: it does not change separator persistence, drag-and-drop behavior, bar geometry, or styling.

## Regression coverage

`tests/qs-bar-edit-lock-regression.sh` verifies that the V1 `mkMa` and `bMa` handles and the V2 `sepMa` handle all require `barSlot.root.barUnlocked`.